### PR TITLE
Deviations now support bookmarks

### DIFF
--- a/src/dataApi.d.ts
+++ b/src/dataApi.d.ts
@@ -40,10 +40,16 @@ declare module "@novorender/data-js-api" {
         options: {
             addToSelectionBasket: boolean;
         };
-        deviations: {
-            index: number;
-            mixFactor: number;
-        };
+        deviations:
+            | {
+                  index: number; // deprecated in favor of profileId
+                  mixFactor: number;
+                  profileId?: string;
+                  subprofileIndex?: number;
+                  isLegendFloating: boolean;
+                  hiddenGroupIds?: string[];
+              }
+            | undefined;
         subtrees: {
             triangles: boolean;
             lines: boolean;

--- a/src/features/bookmarks/useCreateBookmark.ts
+++ b/src/features/bookmarks/useCreateBookmark.ts
@@ -9,6 +9,12 @@ import { useLazyHighlighted } from "contexts/highlighted";
 import { GroupStatus, isInternalGroup, useLazyObjectGroups } from "contexts/objectGroups";
 import { useLazySelectionBasket } from "contexts/selectionBasket";
 import { selectAreas } from "features/area/areaSlice";
+import {
+    selectDeviationLegendGroups,
+    selectIsLegendFloating,
+    selectSelectedProfileId,
+    selectSelectedSubprofileIndex,
+} from "features/deviations";
 import { selectFollowPath } from "features/followPath/followPathSlice";
 import {
     selectManholeCollisionSettings,
@@ -60,6 +66,10 @@ export function useCreateBookmark() {
     const outlineLasers = useAppSelector(selectOutlineLasers);
     const laserPlane = useAppSelector(selectOutlineLaserPlane);
     const propertyTree = useAppSelector(selectPropertyTreeBookmarkState);
+    const deviationProfileId = useAppSelector(selectSelectedProfileId);
+    const deviationSubprofileIndex = useAppSelector(selectSelectedSubprofileIndex);
+    const deviationLegendFloating = useAppSelector(selectIsLegendFloating);
+    const deviationLegendGroups = useAppSelector(selectDeviationLegendGroups);
 
     const {
         state: { view },
@@ -116,10 +126,19 @@ export function useCreateBookmark() {
                 terrain: {
                     asBackground: terrain.asBackground,
                 },
-                deviations: {
-                    index: deviations.index,
-                    mixFactor: deviations.mixFactor,
-                },
+                deviations:
+                    viewMode === ViewMode.Deviations && deviationProfileId
+                        ? {
+                              index: deviations.index,
+                              mixFactor: deviations.mixFactor,
+                              profileId: deviationProfileId,
+                              subprofileIndex: deviationSubprofileIndex,
+                              isLegendFloating: deviationLegendFloating,
+                              hiddenGroupIds: deviationLegendGroups
+                                  ?.filter((g) => g.status === GroupStatus.Hidden)
+                                  .map((g) => g.id),
+                          }
+                        : undefined,
                 groups: groups.current
                     .filter((group) => !isInternalGroup(group))
                     .filter((group) => group.status !== GroupStatus.None)
@@ -158,7 +177,7 @@ export function useCreateBookmark() {
                     },
                 },
                 followPath:
-                    viewMode === ViewMode.FollowPath &&
+                    (viewMode === ViewMode.FollowPath || viewMode === ViewMode.Deviations) &&
                     followPath.currentCenter &&
                     (followPath.selectedIds.length || followPath.selectedPositions.length)
                         ? {

--- a/src/features/deviations/components/groupsAndColorsHud.tsx
+++ b/src/features/deviations/components/groupsAndColorsHud.tsx
@@ -4,44 +4,34 @@ import { memo, useMemo } from "react";
 
 import { ColorStop } from "apis/dataV2/deviationTypes";
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
-import {
-    GroupStatus,
-    isInternalGroup,
-    ObjectGroup,
-    objectGroupsActions,
-    useDispatchObjectGroups,
-    useObjectGroups,
-} from "contexts/objectGroups";
+import { GroupStatus, isInternalGroup, ObjectGroup, useObjectGroups } from "contexts/objectGroups";
 import { selectView2d } from "features/followPath";
+import { renderActions } from "features/render";
+import { ViewMode } from "types/misc";
 import { vecToRgb } from "utils/color";
-import { uniqueArray } from "utils/misc";
 
-import {
-    deviationsActions,
-    selectDeviationLegendGroups,
-    selectSelectedProfile,
-    selectSelectedSubprofile,
-} from "../deviationsSlice";
+import { deviationsActions, selectDeviationLegendGroups, selectSelectedProfile } from "../deviationsSlice";
 import { formatColorStopPos, sortColorStops } from "../utils";
 
 export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
     widgetMode = false,
+    canDetach = true,
     absPos,
 }: {
     widgetMode?: boolean;
+    canDetach?: boolean;
     absPos: boolean;
 }) {
     const profile = useAppSelector(selectSelectedProfile);
-    const subprofile = useAppSelector(selectSelectedSubprofile);
     const legendGroups = useAppSelector(selectDeviationLegendGroups);
     const objectGroups = useObjectGroups().filter((grp) => !isInternalGroup(grp));
     const dispatch = useAppDispatch();
-    const dispatchObjectGroups = useDispatchObjectGroups();
     const isCrossSection = useAppSelector(selectView2d);
 
-    const fromGroups = useMemo(
+    const deviationColoredGroups = useMemo(
         () =>
             (legendGroups ?? [])
+                .filter((g) => g.isDeviationColored)
                 .map((g1) => {
                     const group = objectGroups.find((g2) => g2.id === g1.id);
                     return group
@@ -57,16 +47,16 @@ export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
 
     const otherGroups = useMemo(
         () =>
-            uniqueArray([...(subprofile?.to.groupIds ?? []), ...(subprofile?.favorites ?? [])])
-                .filter((id) => !fromGroups.some((g) => g.id === id))
-                .map((id) => {
-                    const group = objectGroups.find((g) => g.id === id);
+            (legendGroups ?? [])
+                .filter((g) => !g.isDeviationColored)
+                .map((g1) => {
+                    const group = objectGroups.find((g2) => g2.id === g1.id);
                     if (group) {
                         return isCrossSection ? { ...group, color: "grey" } : group;
                     }
                 })
                 .filter((g) => g) as ObjectGroup[],
-        [fromGroups, subprofile, objectGroups, isCrossSection]
+        [objectGroups, isCrossSection, legendGroups]
     );
 
     const colorStops = useMemo(
@@ -74,24 +64,16 @@ export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
         [profile]
     );
 
-    const handleFromGroupClick = (group: ObjectGroup) => {
+    const handleGroupClick = (group: ObjectGroup) => {
         if (!legendGroups) {
             return;
         }
 
-        const newGroups = legendGroups.map((g) => {
-            if (g.id === group.id) {
-                return { ...g, status: g.status === GroupStatus.Hidden ? GroupStatus.Selected : GroupStatus.Hidden };
-            }
-            return g;
-        });
-        dispatch(deviationsActions.setSelectedSubprofileLegendGroups(newGroups));
-    };
-
-    const handleOtherGroupClick = (group: ObjectGroup) => {
-        dispatchObjectGroups(
-            objectGroupsActions.update(group.id, {
-                status: group.status === GroupStatus.Hidden ? GroupStatus.Selected : GroupStatus.Hidden,
+        dispatch(renderActions.setViewMode(ViewMode.Deviations));
+        dispatch(
+            deviationsActions.toggleHiddenLegendGroup({
+                groupId: group.id,
+                hidden: group.status !== GroupStatus.Hidden,
             })
         );
     };
@@ -104,8 +86,9 @@ export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
     const colorStopNodeHeight = 24;
     const gap = 16;
     const groupsBottom = colorStops.length * colorStopNodeHeight + gap;
-    const headerBottom = groupsBottom + (fromGroups.length + otherGroups.length) * groupNodeHeight;
-    const groupNodeBottom = (index: number) => (fromGroups.length + otherGroups.length - index - 1) * groupNodeHeight;
+    const headerBottom = groupsBottom + (deviationColoredGroups.length + otherGroups.length) * groupNodeHeight;
+    const groupNodeBottom = (index: number) =>
+        (deviationColoredGroups.length + otherGroups.length - index - 1) * groupNodeHeight;
 
     return (
         <>
@@ -129,23 +112,23 @@ export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
                 }
             >
                 {widgetMode ? "Groups" : profile.name}
-                {widgetMode ? (
+                {widgetMode && canDetach ? (
                     <IconButton color="default" onClick={() => dispatch(deviationsActions.setIsLegendFloating(true))}>
                         <OpenInNew />
                     </IconButton>
-                ) : (
+                ) : !widgetMode ? (
                     <IconButton color="default" onClick={() => dispatch(deviationsActions.setIsLegendFloating(false))}>
                         <Close />
                     </IconButton>
-                )}
+                ) : undefined}
             </Box>
             <Box sx={absPos ? { position: "absolute", bottom: groupsBottom } : {}}>
-                {fromGroups.map((group, i) => (
+                {deviationColoredGroups.map((group, i) => (
                     <Box
                         key={group.id}
                         sx={absPos ? { position: "absolute", maxWidth: "300px", bottom: groupNodeBottom(i) } : {}}
                     >
-                        <GroupNode group={group} onClick={handleFromGroupClick} colorStops={colorStops} rainbow />
+                        <GroupNode group={group} onClick={handleGroupClick} colorStops={colorStops} rainbow />
                     </Box>
                 ))}
                 {(otherGroups || []).map((group, i) => (
@@ -156,12 +139,12 @@ export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
                                 ? {
                                       position: "absolute",
                                       maxWidth: "300px",
-                                      bottom: groupNodeBottom(fromGroups.length + i),
+                                      bottom: groupNodeBottom(deviationColoredGroups.length + i),
                                   }
                                 : {}
                         }
                     >
-                        <GroupNode group={group} onClick={handleOtherGroupClick} colorStops={colorStops} />
+                        <GroupNode group={group} onClick={handleGroupClick} colorStops={colorStops} />
                     </Box>
                 ))}
             </Box>

--- a/src/features/deviations/components/subprofileSelect.tsx
+++ b/src/features/deviations/components/subprofileSelect.tsx
@@ -14,7 +14,8 @@ import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { useObjectGroups } from "contexts/objectGroups";
 import { selectLandXmlPaths } from "features/followPath";
 import { useLoadLandXmlPath } from "features/followPath/hooks/useLoadLandXmlPath";
-import { AsyncStatus } from "types/misc";
+import { renderActions } from "features/render";
+import { AsyncStatus, ViewMode } from "types/misc";
 
 import { deviationsActions, selectSelectedProfile, selectSelectedSubprofileIndex } from "../deviationsSlice";
 import { DELETED_DEVIATION_LABEL } from "../utils";
@@ -77,6 +78,7 @@ export function SubprofileSelect() {
 
         const spIndex = Number(e.target.value);
 
+        dispatch(renderActions.setViewMode(ViewMode.Deviations));
         dispatch(deviationsActions.setSelectedSubprofileIndex(spIndex));
     };
 

--- a/src/features/deviations/components/viewSwitchSection.tsx
+++ b/src/features/deviations/components/viewSwitchSection.tsx
@@ -70,8 +70,8 @@ export function ViewSwitchSection() {
             Math.min(selectedCenterLine.parameterBounds[1], Number(profilePos))
         );
 
+        dispatch(renderActions.setViewMode(ViewMode.Deviations));
         dispatch(followPathActions.setView2d(newState));
-        dispatch(renderActions.setViewMode(newState ? ViewMode.FollowPath : ViewMode.Default));
         goToProfile({
             fpObj: fpObj.data,
             p: pos,
@@ -81,6 +81,7 @@ export function ViewSwitchSection() {
     };
 
     const handleTopDownChange = () => {
+        dispatch(renderActions.setViewMode(ViewMode.Deviations));
         dispatch(followPathActions.setView2d(false));
         dispatch(renderActions.setGrid({ enabled: false }));
         dispatch(renderActions.setClippingPlanes({ enabled: false, planes: [] }));

--- a/src/features/deviations/deviationTypes.ts
+++ b/src/features/deviations/deviationTypes.ts
@@ -46,7 +46,6 @@ export type UiDeviationSubprofile = {
     favorites: string[];
     centerLine?: UiCenterLine;
     heightToCeiling?: number;
-    legendGroups: FavoriteGroupState[]; // not saved anywhere
 };
 
 export type UiCenterLine = {
@@ -99,11 +98,12 @@ export type ColorSetupGroup = {
     colorStops: FormField<ColorStopGroup[]>;
 };
 
-export type ColorStopGroup = ColorStop;
-
-export type FavoriteGroupState = {
+export type LegendGroupInfo = {
     id: string;
+    isDeviationColored: boolean;
     status: GroupStatus;
 };
+
+export type ColorStopGroup = ColorStop;
 
 export type ObjectGroupExt = { id: string; name: string; deleted?: boolean };

--- a/src/features/deviations/deviations.tsx
+++ b/src/features/deviations/deviations.tsx
@@ -7,10 +7,11 @@ import { MemoryRouter, Route, Switch, useHistory } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { LogoSpeedDial, Tooltip, WidgetContainer, WidgetHeader } from "components";
 import { featuresConfig } from "config/features";
+import { renderActions } from "features/render";
 import WidgetList from "features/widgetList/widgetList";
 import { useToggle } from "hooks/useToggle";
 import { selectIsAdminScene, selectMaximized, selectMinimized, selectProjectIsV2 } from "slices/explorer";
-import { AsyncStatus } from "types/misc";
+import { AsyncStatus, ViewMode } from "types/misc";
 
 import {
     deviationsActions,
@@ -86,7 +87,7 @@ function WidgetMenu(props: MenuProps) {
     const dispatch = useAppDispatch();
 
     useEffect(() => {
-        dispatch(deviationsActions.setActive(true));
+        dispatch(renderActions.setViewMode(ViewMode.Deviations));
     }, [dispatch]);
 
     useListenCalculationState();

--- a/src/features/deviations/hooks/useMergeFormAndSave.ts
+++ b/src/features/deviations/hooks/useMergeFormAndSave.ts
@@ -11,7 +11,6 @@ import { getObjectData } from "utils/search";
 
 import { deviationsActions, selectDeviationForm, selectDeviationProfiles } from "..";
 import { DeviationForm, DeviationType, UiDeviationConfig, UiDeviationProfile } from "../deviationTypes";
-import { makeLegendGroups } from "../useHandleDeviations";
 import { NEW_DEVIATION_ID } from "../utils";
 import { useSaveDeviationConfig } from "./useSaveDeviationConfig";
 
@@ -55,7 +54,7 @@ export function useMergeFormAndSave() {
             });
 
             dispatch(deviationsActions.setProfiles({ status: AsyncStatus.Success, data: newProfileData }));
-
+            dispatch(deviationsActions.resetHiddenLegendGroupsForProfile({ profileId: profile.id }));
             dispatch(deviationsActions.setDeviationForm(undefined));
 
             return newProfileData;
@@ -165,7 +164,6 @@ async function deviationFormToProfile({
                     groupIds: sp.groups2.value,
                     objectIds: [] as number[],
                 },
-                legendGroups: makeLegendGroups(sp.groups1.value),
             };
         }),
         hasFromAndTo: deviationForm.hasFromAndTo,

--- a/src/features/deviations/hooks/useSetCenterLineFollowPath.ts
+++ b/src/features/deviations/hooks/useSetCenterLineFollowPath.ts
@@ -7,10 +7,10 @@ import { highlightActions, useDispatchHighlighted } from "contexts/highlighted";
 import { followPathActions, selectView2d } from "features/followPath/followPathSlice";
 import { useGoToProfile } from "features/followPath/useGoToProfile";
 import { measureActions } from "features/measure";
-import { renderActions } from "features/render";
+import { renderActions, selectViewMode } from "features/render";
 import { ViewMode } from "types/misc";
 
-import { selectActive, selectSelectedCenterLineId, selectSelectedProfile } from "../deviationsSlice";
+import { selectSelectedCenterLineId, selectSelectedProfile } from "../deviationsSlice";
 
 export function useSetCenterLineFollowPath() {
     const {
@@ -26,7 +26,7 @@ export function useSetCenterLineFollowPath() {
     const followPathId = centerLine?.objectId;
     const dispatchHighlighted = useDispatchHighlighted();
     const installedFollowPathId = useRef<number>();
-    const active = useAppSelector(selectActive);
+    const active = useAppSelector(selectViewMode) === ViewMode.Deviations;
 
     const goToProfile = useGoToProfile();
     const goToProfileRef = useRef(goToProfile);
@@ -68,7 +68,7 @@ export function useSetCenterLineFollowPath() {
 
             installedFollowPathId.current = undefined;
 
-            dispatch(renderActions.setViewMode(ViewMode.FollowPath));
+            dispatch(renderActions.setViewMode(ViewMode.Deviations));
             dispatch(followPathActions.setSelectedPath(followPathId));
             dispatch(followPathActions.setSelectedIds([followPathId]));
             dispatch(followPathActions.setRoadIds(undefined));
@@ -79,8 +79,6 @@ export function useSetCenterLineFollowPath() {
                     max: centerLine.parameterBounds[1],
                 })
             );
-            dispatch(renderActions.setMainObject(followPathId));
-            dispatchHighlighted(highlightActions.setIds([followPathId]));
             dispatch(renderActions.setMainObject(followPathId));
             dispatchHighlighted(highlightActions.setIds([followPathId]));
             let initPos = true;

--- a/src/features/deviations/routes/root.tsx
+++ b/src/features/deviations/routes/root.tsx
@@ -2,8 +2,9 @@ import { Alert, Box, FormControl, InputLabel, MenuItem, Select, Typography, useT
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { Divider, LinearProgress, ScrollBox } from "components";
+import { renderActions } from "features/render";
 import { selectProjectIsV2 } from "slices/explorer";
-import { AsyncStatus, hasFinished } from "types/misc";
+import { AsyncStatus, hasFinished, ViewMode } from "types/misc";
 
 import { ColorStopList } from "../components/colorStop";
 import { DeviationsSnackbar } from "../components/deviationsSnackbar";
@@ -19,6 +20,7 @@ import {
     selectIsLegendFloating,
     selectSaveStatus,
     selectSelectedProfile,
+    selectSelectedSubprofile,
 } from "../deviationsSlice";
 import { DeviationCalculationStatus } from "../deviationTypes";
 
@@ -28,6 +30,7 @@ export function Root() {
     const profiles = useAppSelector(selectDeviationProfiles);
     const profileList = useAppSelector(selectDeviationProfileList);
     const selectedProfile = useAppSelector(selectSelectedProfile);
+    const selectedSubprofile = useAppSelector(selectSelectedSubprofile);
     const dispatch = useAppDispatch();
     const saveStatus = useAppSelector(selectSaveStatus);
     const isSaving = saveStatus.status === AsyncStatus.Loading;
@@ -86,6 +89,7 @@ export function Root() {
                                             value={selectedProfile?.id ?? ""}
                                             label="Select deviation profile"
                                             onChange={(e) => {
+                                                dispatch(renderActions.setViewMode(ViewMode.Deviations));
                                                 dispatch(deviationsActions.setSelectedProfileId(e.target.value));
                                             }}
                                         >
@@ -106,6 +110,7 @@ export function Root() {
                                     colorStops={selectedProfile.colors!.colorStops}
                                     absoluteValues={selectedProfile.colors!.absoluteValues}
                                     onChange={(colorStops) => {
+                                        dispatch(renderActions.setViewMode(ViewMode.Deviations));
                                         dispatch(
                                             deviationsActions.setProfile({
                                                 id: selectedProfile!.id,
@@ -124,11 +129,15 @@ export function Root() {
 
                                 <ViewSwitchSection />
 
-                                {!isLegendFloating && (
+                                {!isLegendFloating || (selectedSubprofile && !selectedSubprofile.centerLine) ? (
                                     <Box mt={2}>
-                                        <GroupsAndColorsHud widgetMode absPos={false} />
+                                        <GroupsAndColorsHud
+                                            widgetMode
+                                            absPos={false}
+                                            canDetach={selectedSubprofile?.centerLine !== undefined}
+                                        />
                                     </Box>
-                                )}
+                                ) : undefined}
                             </Box>
                         )}
                     </ScrollBox>

--- a/src/features/followPath/canvas.tsx
+++ b/src/features/followPath/canvas.tsx
@@ -81,7 +81,7 @@ export function FollowPathCanvas({
 
         ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        if (!roadCrossSectionData || viewMode !== ViewMode.FollowPath) {
+        if (!roadCrossSectionData || !(viewMode === ViewMode.FollowPath || viewMode === ViewMode.Deviations)) {
             return;
         }
 
@@ -406,17 +406,17 @@ export function FollowPathCanvas({
         drawDeviations,
     ]);
 
-    const canDrawRoad = roadCrossSectionData && viewMode === ViewMode.FollowPath;
+    const isFollowPathOrDeviations = viewMode === ViewMode.FollowPath || viewMode === ViewMode.Deviations;
+    const canDrawRoad = roadCrossSectionData && isFollowPathOrDeviations;
     const canDrawSelectedEntity = drawSelectedEntities && Boolean(selectedEntitiesData?.length);
     const canDrawTracer =
         showTracer &&
         cameraType === CameraType.Orthographic &&
-        viewMode === ViewMode.FollowPath &&
+        isFollowPathOrDeviations &&
         roadCrossSectionData &&
         roadCrossSectionData.length >= 2;
-    const canDrawProfile = viewMode === ViewMode.FollowPath && currentProfileCenter && currentProfile;
-    const canDrawDeviations =
-        viewMode === ViewMode.FollowPath && cameraType == CameraType.Orthographic && currentProfileCenter;
+    const canDrawProfile = isFollowPathOrDeviations && currentProfileCenter && currentProfile;
+    const canDrawDeviations = isFollowPathOrDeviations && cameraType == CameraType.Orthographic && currentProfileCenter;
 
     return (
         <>

--- a/src/features/followPath/follow.tsx
+++ b/src/features/followPath/follow.tsx
@@ -16,14 +16,14 @@ import {
 } from "@mui/material";
 import { FollowParametricObject } from "@novorender/api";
 import { HierarcicalObjectReference } from "@novorender/webgl-api";
-import { FormEvent, MouseEvent, SyntheticEvent, useEffect, useState } from "react";
+import { FormEvent, MouseEvent, SyntheticEvent, useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { Accordion, AccordionDetails, AccordionSummary, Divider, IosSwitch, ScrollBox, Tooltip } from "components";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { ColorPicker } from "features/colorPicker";
-import { renderActions } from "features/render";
+import { renderActions, selectViewMode } from "features/render";
 import { AsyncStatus, ViewMode } from "types/misc";
 import { rgbToVec, vecToRgb } from "utils/color";
 import { uniqueArray } from "utils/misc";
@@ -80,11 +80,17 @@ export function Follow({ fpObj }: { fpObj: FollowParametricObject }) {
     const traceVerical = useAppSelector(selectVerticalTracer);
     const deviations = useAppSelector(selectFollowDeviations);
     const goToProfile = useGoToProfile();
+    const viewMode = useAppSelector(selectViewMode);
+    const viewModeRef = useRef(viewMode);
 
     const [profileInput, setProfileInput] = useState(profile);
     const [clipping, setClipping] = useState(_clipping);
 
     const dispatch = useAppDispatch();
+
+    useEffect(() => {
+        viewModeRef.current = viewMode;
+    }, [viewMode]);
 
     useEffect(() => setClipping(_clipping), [_clipping]);
 
@@ -308,10 +314,14 @@ export function Follow({ fpObj }: { fpObj: FollowParametricObject }) {
     };
 
     useEffect(() => {
-        dispatch(renderActions.setViewMode(ViewMode.FollowPath));
+        if (viewModeRef.current !== ViewMode.Deviations) {
+            dispatch(renderActions.setViewMode(ViewMode.FollowPath));
+        }
 
         return () => {
-            dispatch(renderActions.setViewMode(ViewMode.Default));
+            if (viewModeRef.current === ViewMode.FollowPath) {
+                dispatch(renderActions.setViewMode(ViewMode.Default));
+            }
         };
     }, [dispatch]);
 

--- a/src/features/followPath/followHtmlInteractions.tsx
+++ b/src/features/followPath/followHtmlInteractions.tsx
@@ -7,7 +7,7 @@ import { forwardRef, memo, SyntheticEvent, useCallback, useEffect, useImperative
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { areArraysEqual } from "features/arcgis/utils";
-import { selectActive, selectIsLegendFloating, selectRightmost2dDeviationCoordinate } from "features/deviations";
+import { selectIsLegendFloating, selectRightmost2dDeviationCoordinate } from "features/deviations";
 import { GroupsAndColorsHud } from "features/deviations/components/groupsAndColorsHud";
 import { useIsTopDownOrthoCamera } from "features/deviations/hooks/useIsTopDownOrthoCamera";
 import { CameraType, selectBackground, selectCameraType } from "features/render";
@@ -47,7 +47,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
     const [centerLinePt, setCenterLinePt] = useState<ReadonlyVec2>();
     const legendOffset = useRef(160);
     const lastFov = useRef<number>();
-    const active = useAppSelector(selectActive);
+    const isActive = viewMode === ViewMode.FollowPath || viewMode === ViewMode.Deviations;
 
     const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -113,7 +113,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
         findPoint();
 
         async function findPoint() {
-            if (!view?.measure || !followPathId || !active) {
+            if (!view?.measure || !followPathId || !isActive) {
                 setCenterLinePt(undefined);
                 return;
             }
@@ -137,14 +137,14 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
                 }
             }
         }
-    }, [view?.measure, view?.renderState.camera, followPathId, active]);
+    }, [view?.measure, view?.renderState.camera, followPathId, isActive]);
 
-    if (!active) {
+    if (!isActive) {
         return;
     }
 
     if (isCrossSectionView) {
-        if (!view?.measure || !currentProfileCenter || viewMode !== ViewMode.FollowPath) {
+        if (!view?.measure || !currentProfileCenter) {
             return null;
         }
 
@@ -196,7 +196,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
                     <FollowPathControls />
                 </div>
 
-                {isLegendFloating && (
+                {viewMode === ViewMode.Deviations && isLegendFloating && (
                     <div
                         style={{
                             position: "absolute",
@@ -210,7 +210,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
                 )}
             </div>
         );
-    } else if (centerLinePt && isLegendFloating) {
+    } else if (viewMode === ViewMode.Deviations && centerLinePt && isLegendFloating) {
         return (
             <LegendAlongCenterLine
                 style={{

--- a/src/features/home/useResetView.ts
+++ b/src/features/home/useResetView.ts
@@ -71,7 +71,6 @@ export function useResetView() {
                     )
                 )
             );
-            dispatch(deviationsActions.setActive(false));
         } catch (e) {
             console.warn(e);
         }

--- a/src/features/render/hooks/useCanvasClickHandler.ts
+++ b/src/features/render/hooks/useCanvasClickHandler.ts
@@ -107,7 +107,9 @@ export function useCanvasClickHandler({
         pointerDownStateRef.current = undefined;
         const pickCameraPlane =
             cameraState.type === CameraType.Orthographic &&
-            (viewMode === ViewMode.CrossSection || viewMode === ViewMode.FollowPath);
+            (viewMode === ViewMode.CrossSection ||
+                viewMode === ViewMode.FollowPath ||
+                viewMode === ViewMode.Deviations);
 
         const isTouch = evt.nativeEvent instanceof PointerEvent && evt.nativeEvent.pointerType === "touch";
         const pickOutline = measure.snapKind === "clippingOutline" && picker === Picker.Measurement;

--- a/src/features/render/hooks/useCanvasEventHandlers.ts
+++ b/src/features/render/hooks/useCanvasEventHandlers.ts
@@ -404,7 +404,7 @@ export function useCanvasEventHandlers({
             !stamp?.pinned &&
             deviation.mixFactor !== 0 &&
             cameraType === CameraType.Orthographic &&
-            [ViewMode.CrossSection, ViewMode.FollowPath].includes(viewMode) &&
+            [ViewMode.CrossSection, ViewMode.FollowPath, ViewMode.Deviations].includes(viewMode) &&
             e.buttons === 0 &&
             subtrees.points === SubtreeStatus.Shown;
         if (setDeviationStamp) {

--- a/src/features/render/hooks/useHandleHighlights.ts
+++ b/src/features/render/hooks/useHandleHighlights.ts
@@ -201,7 +201,9 @@ export function useHandleHighlights() {
                             ).sort(),
                             action: group.action,
                         })),
-                        ...(cameraType === CameraType.Orthographic && viewMode !== ViewMode.FollowPath
+                        ...(cameraType === CameraType.Orthographic &&
+                        viewMode !== ViewMode.FollowPath &&
+                        viewMode !== ViewMode.Deviations
                             ? outlineGroups.map((group) => ({
                                   objectIds: new Uint32Array(group.ids).sort().filter((f) => !allHidden.has(f)),
                                   outlineColor: group.color,

--- a/src/features/render/renderSlice.ts
+++ b/src/features/render/renderSlice.ts
@@ -618,6 +618,9 @@ export const renderSlice = createSlice({
             state.picker = initialState.picker;
             state.clipping = initialState.clipping;
             state.selectionBasketMode = initialState.selectionBasketMode;
+            if (state.viewMode === ViewMode.Deviations) {
+                state.viewMode = ViewMode.Default;
+            }
 
             // Camera
             if (initialCamera) {
@@ -714,8 +717,10 @@ export const renderSlice = createSlice({
                 : (objects.defaultVisibility as ObjectVisibility);
             state.background.color = background.color;
             state.terrain.asBackground = terrain.asBackground;
-            state.points.deviation.index = deviations.index;
-            state.points.deviation.mixFactor = deviations.mixFactor;
+            if (deviations) {
+                state.points.deviation.index = deviations.index;
+                state.points.deviation.mixFactor = deviations.mixFactor;
+            }
             state.grid = grid;
             state.clipping = {
                 ...clipping,

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -31,6 +31,7 @@ export type ExtendedMeasureEntity = MeasureEntity & {
 export enum ViewMode {
     Default = "default",
     FollowPath = "followPath",
+    Deviations = "deviations",
     CrossSection = "crossSection",
     Panorama = "panorama",
 }


### PR DESCRIPTION
https://trello.com/c/EA1Lnwd6/761-deviations-support-bookmarks

- Info we save is profile ID, subprofile index, active and hidden groups
- Changed storage mechanism for hidden groups because of that
- Instead of "active" flag in deviations use ViewMode.Deviations. Most FollowPath functionality works in this mode as well
- When doing actions inside Deviations root view - set view mode to Deviations in case somebody did reset view before
- Better support for reset view
- Group list is always shown in Deviations root when subprofile doesn't have a center line