### PR TITLE
Set visibility to semiTransparent when geo form is open or added

### DIFF
--- a/src/features/forms/routes/formsList/formsList.tsx
+++ b/src/features/forms/routes/formsList/formsList.tsx
@@ -56,17 +56,17 @@ export function FormsList() {
     >(
         template?.type === TemplateType.Search
             ? template.objects!.map((object: FormObject) => ({
-                  ...object,
-                  id: -1,
-                  formState: template.forms![object.guid].state,
-              }))
+                ...object,
+                id: -1,
+                formState: template.forms![object.guid].state,
+            }))
             : template?.type === TemplateType.Location
-            ? Object.entries(template?.forms ?? {}).map(([id, form]: [string, FormRecord]) => ({
-                  ...form,
-                  formState: form.state,
-                  id: Number(id),
-              }))
-            : []
+                ? Object.entries(template?.forms ?? {}).map(([id, form]: [string, FormRecord]) => ({
+                    ...form,
+                    formState: form.state,
+                    id: Number(id),
+                }))
+                : []
     );
     const [loadingItems, setLoadingItems] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -151,9 +151,9 @@ export function FormsList() {
                 if (template?.type === TemplateType.Search) {
                     dispatchHighlighted(highlightActions.setIds([]));
                     dispatchHighlightCollections(highlightCollectionsActions.clearAll());
-                    dispatch(renderActions.setDefaultVisibility(ObjectVisibility.Neutral));
                     dispatchHighlighted(highlightActions.resetColor());
                 }
+                dispatch(renderActions.setDefaultVisibility(ObjectVisibility.Neutral));
                 dispatch(formsActions.setCurrentFormsList(null));
             }
         },
@@ -190,6 +190,7 @@ export function FormsList() {
 
     useEffect(() => {
         if (template?.type !== TemplateType.Search) {
+            dispatch(renderActions.setDefaultVisibility(items.length > 0 ? ObjectVisibility.SemiTransparent : ObjectVisibility.Neutral));
             return;
         }
 

--- a/src/features/forms/routes/instance/locationInstance.tsx
+++ b/src/features/forms/routes/instance/locationInstance.tsx
@@ -14,6 +14,7 @@ import { useFlyToForm } from "features/forms/hooks/useFlyToForm";
 import { formsActions, selectCurrentFormsList } from "features/forms/slice";
 import { type FormId, type FormItem as FItype, FormItemType, type TemplateId } from "features/forms/types";
 import { toFormFields, toFormItems } from "features/forms/utils";
+import { ObjectVisibility, renderActions } from "features/render";
 import { useSceneId } from "hooks/useSceneId";
 
 import { FormItem } from "./formItem";
@@ -39,6 +40,7 @@ export function LocationInstance() {
     });
 
     useEffect(() => {
+        dispatch(renderActions.setDefaultVisibility(ObjectVisibility.SemiTransparent));
         dispatch(formsActions.setSelectedFormId(formId));
     }, [dispatch, formId]);
 


### PR DESCRIPTION
Entering the object form should make other objects transparent. Otherwise object might be not noticeable enough, e.g. when flying to it and there's smth between camera and the object.

[CARD](https://trello.com/c/hBCdLw9e)