### PR TITLE
ArcGIS: use `objectIdField` instead of hardcoded "OBJECTID"

### DIFF
--- a/src/features/arcgis/hooks/useLoadFeaturesAndDefinition.ts
+++ b/src/features/arcgis/hooks/useLoadFeaturesAndDefinition.ts
@@ -118,7 +118,7 @@ async function loadFeatures(
 
     // Using request instead of queryFeatures because queryFeatures doesn't
     // seem to support signal
-    const fields = ["OBJECTID"];
+    const fields = [definition.objectIdField];
     if (definition.drawingInfo.renderer.type === "uniqueValue") {
         fields.push(definition.drawingInfo.renderer.field1);
     }


### PR DESCRIPTION
https://trello.com/c/TR6IbGtA/777-arcgis-use-objectidfield-instead-of-hardcoded-objectid