### PR TITLE
Deviations and follow path are available offline

### DIFF
--- a/src/features/deviations/components/subprofileList.tsx
+++ b/src/features/deviations/components/subprofileList.tsx
@@ -15,6 +15,7 @@ export function SubprofileList({
     objectGroups,
     onClick,
     onDelete,
+    disabled,
 }: {
     subprofiles: SubprofileGroup[];
     errors: SubprofileGroupErrors[];
@@ -22,6 +23,7 @@ export function SubprofileList({
     objectGroups: ObjectGroup[];
     onClick: (sp: SubprofileGroup, index: number) => void;
     onDelete: (sp: SubprofileGroup, index: number) => void;
+    disabled?: boolean;
 }) {
     return (
         <List>
@@ -35,6 +37,7 @@ export function SubprofileList({
                         onDelete={() => onDelete(sp, i)}
                         selected={i === selectedIndex}
                         errors={errors[i]}
+                        disabled={disabled}
                     />
                 );
             })}

--- a/src/features/deviations/deviations.tsx
+++ b/src/features/deviations/deviations.tsx
@@ -10,7 +10,13 @@ import { featuresConfig } from "config/features";
 import { renderActions } from "features/render";
 import WidgetList from "features/widgetList/widgetList";
 import { useToggle } from "hooks/useToggle";
-import { selectIsAdminScene, selectMaximized, selectMinimized, selectProjectIsV2 } from "slices/explorer";
+import {
+    selectIsAdminScene,
+    selectIsOnline,
+    selectMaximized,
+    selectMinimized,
+    selectProjectIsV2,
+} from "slices/explorer";
 import { AsyncStatus, ViewMode } from "types/misc";
 
 import { deviationsActions } from "./deviationsSlice";
@@ -84,6 +90,7 @@ function WidgetMenu(props: MenuProps) {
     const config = useAppSelector(selectDeviationProfiles);
     const selectedProfile = useAppSelector(selectSelectedProfile);
     const isDeviationFormSet = useAppSelector((state) => selectDeviationForm(state) !== undefined);
+    const isOnline = useAppSelector(selectIsOnline);
     const dispatch = useAppDispatch();
 
     useEffect(() => {
@@ -139,7 +146,7 @@ function WidgetMenu(props: MenuProps) {
                             closeMenu();
                             history.push("/deviation/delete", { id: selectedProfile!.id! });
                         }}
-                        disabled={!selectedProfile || isDeviationFormSet}
+                        disabled={!selectedProfile || isDeviationFormSet || !isOnline}
                     >
                         <ListItemIcon>
                             <Delete fontSize="small" />
@@ -165,7 +172,8 @@ function WidgetMenu(props: MenuProps) {
                                     config.status !== AsyncStatus.Success ||
                                     config.data.profiles.length === MAX_DEVIATION_PROFILE_COUNT ||
                                     !isProjectV2 ||
-                                    isDeviationFormSet
+                                    isDeviationFormSet ||
+                                    !isOnline
                                 }
                             >
                                 <ListItemIcon>

--- a/src/features/deviations/routes/deviation.tsx
+++ b/src/features/deviations/routes/deviation.tsx
@@ -27,7 +27,7 @@ import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { Divider, LinearProgress, ScrollBox } from "components";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { isInternalGroup, ObjectGroup, useObjectGroups } from "contexts/objectGroups";
-import { selectProjectIsV2 } from "slices/explorer";
+import { selectIsOnline, selectProjectIsV2 } from "slices/explorer";
 import { AsyncStatus } from "types/misc";
 
 import { CenterLineSection } from "../components/centerLineSection";
@@ -75,6 +75,7 @@ export function Deviation() {
     const saveStatus = useAppSelector(selectSaveStatus);
     const objectGroups = useObjectGroups().filter((grp) => !isInternalGroup(grp));
     const containerRef = useRef<HTMLElement>();
+    const isOnline = useAppSelector(selectIsOnline);
 
     const deviationForm = useAppSelector(selectDeviationForm) ?? newDeviationForm();
     const subprofile = deviationForm.subprofiles[deviationForm.subprofileIndex];
@@ -109,7 +110,7 @@ export function Deviation() {
     const errors = validateDeviationForm(deviationForm, otherNames, objectGroups);
     const subprofileErrors = errors.subprofiles[deviationForm.subprofileIndex];
 
-    const formDisabled = !isProjectV2;
+    const formDisabled = !isProjectV2 || !isOnline;
 
     const groups1 = useMemo(
         () => selectGroupsForIds(objectGroups, subprofile.groups1.value),
@@ -319,6 +320,7 @@ export function Deviation() {
                                                 : deviationForm.subprofileIndex - 1,
                                     });
                                 }}
+                                disabled={formDisabled}
                             />
                         </Box>
                     </>

--- a/src/features/followPath/canvas.tsx
+++ b/src/features/followPath/canvas.tsx
@@ -5,7 +5,7 @@ import { MutableRefObject, useCallback, useEffect, useRef, useState } from "reac
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { Canvas2D } from "components";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
-import { deviationsActions } from "features/deviations";
+import { deviationsActions } from "features/deviations/deviationsSlice";
 import { useIsTopDownOrthoCamera } from "features/deviations/hooks/useIsTopDownOrthoCamera";
 import {
     drawLineStrip,

--- a/src/features/followPath/followPathSlice.ts
+++ b/src/features/followPath/followPathSlice.ts
@@ -7,10 +7,7 @@ import { selectBookmark } from "features/render";
 import { AsyncState, AsyncStatus } from "types/misc";
 import { VecRGBA } from "utils/color";
 
-type LandXmlPath = {
-    id: number;
-    name: string;
-};
+import { LandXmlPath } from "./types";
 
 const initialState = {
     paths: { status: AsyncStatus.Initial } as AsyncState<LandXmlPath[]>,

--- a/src/features/followPath/hooks/useLoadLandXmlPath.ts
+++ b/src/features/followPath/hooks/useLoadLandXmlPath.ts
@@ -1,19 +1,30 @@
-import { useEffect } from "react";
+import { HierarcicalObjectReference } from "@novorender/webgl-api";
+import { useEffect, useRef } from "react";
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
+import { useSceneId } from "hooks/useSceneId";
+import { selectIsOnline } from "slices/explorer";
 import { AsyncStatus } from "types/misc";
+import { getManualCache } from "utils/manualCache";
 import { getObjectNameFromPath, getParentPath } from "utils/objectData";
 import { searchByPatterns } from "utils/search";
 
 import { followPathActions, selectLandXmlPaths } from "../followPathSlice";
+import { LandXmlPath } from "../types";
 
 export function useLoadLandXmlPath({ skip }: { skip?: boolean } = {}) {
     const {
         state: { db },
-    } = useExplorerGlobals(true);
+    } = useExplorerGlobals();
     const landXmlPaths = useAppSelector(selectLandXmlPaths);
     const dispatch = useAppDispatch();
+    const projectId = useSceneId();
+    const isOnline = useAppSelector(selectIsOnline);
+    const isOnlineRef = useRef(isOnline);
+    useEffect(() => {
+        isOnlineRef.current = isOnline;
+    });
 
     useEffect(() => {
         if (!skip && landXmlPaths.status === AsyncStatus.Initial) {
@@ -21,33 +32,65 @@ export function useLoadLandXmlPath({ skip }: { skip?: boolean } = {}) {
         }
 
         async function getLandXmlPaths() {
+            if (!db) {
+                return;
+            }
+
             dispatch(followPathActions.setPaths({ status: AsyncStatus.Loading }));
 
+            const cacheKey = `/derived/projects/${projectId}/landXmlPaths`;
+
             try {
-                let paths = [] as {
-                    id: number;
-                    name: string;
-                }[];
+                let paths = [] as LandXmlPath[];
 
-                await searchByPatterns({
-                    db,
-                    searchPatterns: [{ property: "Novorender/PathId" }],
-                    callback: (refs) =>
-                        (paths = paths.concat(
-                            refs.map(({ path, id }) => ({ id, name: getObjectNameFromPath(getParentPath(path)) }))
-                        )),
-                });
+                const cache = await getManualCache();
 
-                if (paths.length == 0) {
-                    //Legacy
+                if (!isOnlineRef.current) {
+                    const resp = await cache.match(cacheKey);
+                    if (resp) {
+                        paths = await resp.json();
+                    } else {
+                        throw new Error("No cached value for land XML paths");
+                    }
+                } else {
+                    const refsWithPathId: HierarcicalObjectReference[] = [];
+
                     await searchByPatterns({
                         db,
-                        searchPatterns: [{ property: "Novorender/Path", value: "true", exact: true }],
-                        callback: (refs) =>
-                            (paths = paths.concat(
-                                refs.map(({ path, id }) => ({ id, name: getObjectNameFromPath(getParentPath(path)) }))
-                            )),
+                        searchPatterns: [{ property: "Novorender/PathId" }],
+                        full: true,
+                        callback: (refs) => {
+                            refsWithPathId.push(...refs);
+                        },
                     });
+
+                    paths = await Promise.all(
+                        refsWithPathId.map(async (ref) => {
+                            const meta = await ref.loadMetaData();
+                            return {
+                                id: ref.id,
+                                name: getObjectNameFromPath(getParentPath(ref.path)),
+                                brepId: meta.properties.find((p) => p[0] === "Novorender/PathId")![1],
+                            };
+                        })
+                    );
+
+                    if (paths.length == 0) {
+                        //Legacy
+                        await searchByPatterns({
+                            db,
+                            searchPatterns: [{ property: "Novorender/Path", value: "true", exact: true }],
+                            callback: (refs) =>
+                                (paths = paths.concat(
+                                    refs.map(({ path, id }) => ({
+                                        id,
+                                        name: getObjectNameFromPath(getParentPath(path)),
+                                    }))
+                                )),
+                        });
+                    }
+
+                    cache.put(cacheKey, Response.json(paths));
                 }
 
                 paths.sort((a, b) => a.name.localeCompare(b.name, "en", { sensitivity: "accent" }));
@@ -62,5 +105,5 @@ export function useLoadLandXmlPath({ skip }: { skip?: boolean } = {}) {
                 );
             }
         }
-    }, [db, landXmlPaths, dispatch, skip]);
+    }, [db, landXmlPaths, dispatch, skip, projectId]);
 }

--- a/src/features/followPath/types.ts
+++ b/src/features/followPath/types.ts
@@ -1,0 +1,5 @@
+export type LandXmlPath = {
+    id: number;
+    name: string;
+    brepId?: string;
+};

--- a/src/utils/manualCache.ts
+++ b/src/utils/manualCache.ts
@@ -1,0 +1,3 @@
+export function getManualCache() {
+    return caches.open("novorender-explorer-runtime-manual");
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,6 +88,48 @@ const pwaOptions: Partial<VitePWAOptions> = {
                     },
                 },
             },
+            // Project info
+            {
+                urlPattern: /^https:\/\/data-v2(-staging)?\.novorender\.com\/projects\/[\w]{32}$/,
+                handler: "NetworkFirst",
+                options: {
+                    cacheableResponse: {
+                        statuses: [0, 200],
+                    },
+                },
+            },
+            // Deviations
+            {
+                urlPattern: /^https:\/\/novorenderblobs\.blob\.core\.windows\.net\/[\w]{32}\/deviations\.json/,
+                handler: "NetworkFirst",
+                options: {
+                    cacheableResponse: {
+                        statuses: [0, 200],
+                    },
+                    matchOptions: {
+                        ignoreSearch: true,
+                    },
+                    plugins: [
+                        {
+                            cacheKeyWillBeUsed: async (param) => {
+                                const url = new URL(param.request.url);
+                                url.search = "";
+                                return url.toString();
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                urlPattern: /^https:\/\/data-v2(-staging)?\.novorender\.com\/explorer\/[\w]{32}\/deviations$/,
+                handler: "NetworkFirst",
+                options: {
+                    cacheableResponse: {
+                        statuses: [0, 200],
+                    },
+                },
+            },
+            // config.json
             {
                 urlPattern: (options) => {
                     if (!options.sameOrigin) {


### PR DESCRIPTION
https://trello.com/c/VOTBFW0n/753-offilne-improvements-when-device-is-out-of-disk-space

- Deviations and project v2 info are cached by vite-pwa
- Follow paths are cached manually because it's easier to cache search result this way
- brep ID is loaded together with main land XML fetches now
- Deviation widget disables things properly when offline