### PR TITLE
Adv. Settings - use latest server settings for `properties`

### DIFF
--- a/src/features/advancedSettings/advancedSettings.tsx
+++ b/src/features/advancedSettings/advancedSettings.tsx
@@ -108,7 +108,8 @@ export default function AdvancedSettings() {
                             .filter((widget) => widget.type !== FeatureType.AdminWidget)
                             .map((widget) => widget.key),
                     },
-                    properties: propertiesSettings,
+                    properties:
+                        originalScene.customProperties.explorerProjectState?.features?.properties ?? propertiesSettings,
                     navigationCube: navigationCube,
                     debugStats: debugStats,
                     primaryMenu: {


### PR DESCRIPTION
https://trello.com/c/pbBfMbBa/784-adv-settings-dont-overwrite-properties

Properties settings are updated in "Properties" widget, so it doesn't really make sense to update them here. People end up overwriting other people changes more often.