### PR TITLE
ArcGIS: require feature server URL to end with FeatureServer (plus optional layer ID)

### DIFF
--- a/src/features/arcgis/routes/editFeatureServer.tsx
+++ b/src/features/arcgis/routes/editFeatureServer.tsx
@@ -82,6 +82,15 @@ export function EditFeatureServer() {
                 return;
             }
 
+            const parsedUrl = new URL(fsUrl);
+            if (!parsedUrl.pathname.match(/\/FeatureServer\/?$/)) {
+                setFsDefinition({
+                    status: AsyncStatus.Error,
+                    msg: "Only feature servers are supported at the moment",
+                });
+                return;
+            }
+
             setFsDefinition({ status: AsyncStatus.Loading });
 
             try {


### PR DESCRIPTION
https://trello.com/c/2x9MmbAS/783-arcgis-forbid-adding-sceneserver

People were trying to add SceneServer and it was valid because response has `layers` field.