### PR TITLE
Deviations: only show legend groups in legend

### DIFF
--- a/src/features/deviations/components/groupsAndColorsHud.tsx
+++ b/src/features/deviations/components/groupsAndColorsHud.tsx
@@ -112,7 +112,7 @@ export const GroupsAndColorsHud = memo(function GroupsAndColorsHud({
                         : {}
                 }
             >
-                {widgetMode ? "Groups" : profile.name}
+                {widgetMode ? (legendGroups.length === 0 && !canDetach ? "" : "Legend") : profile.name}
                 {widgetMode && canDetach ? (
                     <IconButton color="default" onClick={() => dispatch(deviationsActions.setIsLegendFloating(true))}>
                         <OpenInNew />

--- a/src/features/deviations/hooks/useHighlightDeviation.ts
+++ b/src/features/deviations/hooks/useHighlightDeviation.ts
@@ -6,7 +6,6 @@ import {
     highlightCollectionsActions,
     useDispatchHighlightCollections,
 } from "contexts/highlightCollections";
-import { useDispatchHighlighted } from "contexts/highlighted";
 import {
     GroupStatus,
     ObjectGroup,
@@ -18,19 +17,19 @@ import { ObjectVisibility, renderActions, selectDefaultVisibility, selectViewMod
 import { useSceneId } from "hooks/useSceneId";
 import { ViewMode } from "types/misc";
 
-import { selectDeviationLegendGroups, selectSelectedCenterLineFollowPathId, selectSelectedProfile } from "../selectors";
+import { selectAllDeviationGroups, selectSelectedCenterLineFollowPathId, selectSelectedProfile } from "../selectors";
 import { fillGroupIds } from "../utils";
 
 export function useHighlightDeviation() {
-    const legendGroups = useAppSelector(selectDeviationLegendGroups);
+    const legendGroups = useAppSelector(selectAllDeviationGroups);
     const followPathId = useAppSelector(selectSelectedCenterLineFollowPathId);
     const objectGroups = useObjectGroups();
     const dispatch = useAppDispatch();
-    const dispatchHighlighted = useDispatchHighlighted();
     const dispatchObjectGroups = useDispatchObjectGroups();
     const dispatchHighlightCollections = useDispatchHighlightCollections();
     const deviationType = useAppSelector(selectSelectedProfile)?.deviationType;
-    const active = useAppSelector(selectViewMode) === ViewMode.Deviations;
+    const viewMode = useAppSelector(selectViewMode);
+    const active = viewMode === ViewMode.Deviations;
     const sceneId = useSceneId();
 
     const objectGroupsRef = useRef(objectGroups);
@@ -97,17 +96,7 @@ export function useHighlightDeviation() {
 
             installed.current = true;
         }
-    }, [
-        dispatch,
-        dispatchHighlightCollections,
-        dispatchHighlighted,
-        legendGroups,
-        restore,
-        followPathId,
-        objectGroups,
-        active,
-        sceneId,
-    ]);
+    }, [dispatch, dispatchHighlightCollections, legendGroups, restore, followPathId, objectGroups, active, sceneId]);
 
     // Sync non deviation-colored groups with objectGroups
     useEffect(() => {

--- a/src/features/deviations/hooks/useSetCenterLineFollowPath.ts
+++ b/src/features/deviations/hooks/useSetCenterLineFollowPath.ts
@@ -42,7 +42,7 @@ export function useSetCenterLineFollowPath() {
 
     const restore = useCallback(() => {
         if (installedFollowPathId.current !== undefined) {
-            dispatch(renderActions.setViewMode(ViewMode.Default));
+            // dispatch(renderActions.setViewMode(ViewMode.Default));
             dispatch(followPathActions.setSelectedPath(undefined));
             dispatch(followPathActions.setSelectedIds([]));
             dispatch(followPathActions.setProfileRange(undefined));

--- a/src/features/deviations/selectors.ts
+++ b/src/features/deviations/selectors.ts
@@ -50,7 +50,7 @@ const selectCurrentHiddenLegendGroups = createSelector(
         return allHiddenGroups[profileId]?.[spIndex];
     }
 );
-export const selectDeviationLegendGroups = createSelector(
+export const selectAllDeviationGroups = createSelector(
     [selectSelectedProfile, selectSelectedSubprofileIndex, selectSelectedSubprofile, selectCurrentHiddenLegendGroups],
     (profile, spIndex, sp, hiddenGroupIds) => {
         if (!profile || spIndex === undefined || !sp) {
@@ -71,5 +71,15 @@ export const selectDeviationLegendGroups = createSelector(
             ...g,
             status: hiddenGroupIds?.includes(g.id) ? GroupStatus.Hidden : GroupStatus.Selected,
         })) as LegendGroupInfo[];
+    }
+);
+export const selectDeviationLegendGroups = createSelector(
+    [selectSelectedSubprofile, selectAllDeviationGroups],
+    (sp, groups) => {
+        if (!sp || !groups) {
+            return [];
+        }
+
+        return groups.filter((g) => sp.favorites.includes(g.id));
     }
 );

--- a/src/features/followPath/followHtmlInteractions.tsx
+++ b/src/features/followPath/followHtmlInteractions.tsx
@@ -24,6 +24,7 @@ import {
     selectCurrentCenter,
     selectFollowObject,
     selectProfile,
+    selectSelectedPath,
     selectView2d,
 } from "./followPathSlice";
 import { useFollowPathFromIds } from "./useFollowPathFromIds";
@@ -47,6 +48,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
     const isBlackBg = bgColor && areArraysEqual(bgColor.color, [0, 0, 0, 1]);
     const legendOffset = useRef(160);
     const lastFov = useRef<number>();
+    const followPath = useAppSelector(selectSelectedPath);
     const isActive = viewMode === ViewMode.FollowPath || viewMode === ViewMode.Deviations;
     const centerLinePt = useAppSelector(selectClosestToCenterFollowPathPoint);
 
@@ -129,7 +131,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
                     <FollowPathControls />
                 </div>
 
-                {viewMode === ViewMode.Deviations && isLegendFloating && (
+                {viewMode === ViewMode.Deviations && followPath && isLegendFloating && (
                     <div
                         style={{
                             position: "absolute",
@@ -143,7 +145,7 @@ export const FollowHtmlInteractions = forwardRef(function FollowHtmlInteractions
                 )}
             </div>
         );
-    } else if (viewMode === ViewMode.Deviations && centerLinePt && isLegendFloating) {
+    } else if (viewMode === ViewMode.Deviations && followPath && centerLinePt && isLegendFloating) {
         const centerX = window.innerWidth / 2;
         const centerY = window.innerHeight / 2;
 


### PR DESCRIPTION
https://trello.com/c/xDt16wuJ/786-deviations-legend-should-only-contain-favourite-groups

Deviations legend used to show combination of groups to analyse, analyse against and legend groups. Instead we only need to show legend groups, so if groups to analyse/analyse against are not listed in legend groups - they can't be hidden.

In addition fixed an issue where we change view mode to default for profiles without center line and it changes visibility mode to default and we see more than we should.