### PR TITLE
Properties: don't limit property count

### DIFF
--- a/src/features/properties/routes/root.tsx
+++ b/src/features/properties/routes/root.tsx
@@ -156,7 +156,7 @@ export function Root() {
 
             const cleanedObjectData = {
                 ..._objectData,
-                properties: _objectData.properties.filter(([_prop, value]) => Boolean(value)).slice(0, 100),
+                properties: _objectData.properties.filter(([_prop, value]) => Boolean(value)),
             };
             const parent = navigator.onLine
                 ? await searchFirstObjectAtPath({ db, path: getParentPath(_objectData.path) })
@@ -165,7 +165,7 @@ export function Root() {
             if (parent) {
                 const parentPropertiesObject = createPropertiesObject({
                     ...parent,
-                    properties: parent.properties.filter(([_prop, value]) => Boolean(value)).slice(0, 50),
+                    properties: parent.properties.filter(([_prop, value]) => Boolean(value)),
                 });
                 setObject({ ...createPropertiesObject(cleanedObjectData), parent: parentPropertiesObject });
             } else {


### PR DESCRIPTION
https://trello.com/c/bEwPCVuK/795-properties-dont-limit-property-count

For some reason Properties widget only shows 100 properties and 50 parent properties. Because of this users don't see some properties they'd like to see. Noone knows why and commit/trello history doesn't show enough details.