### PR TITLE
Selection: when in single selection mode and multiple objects are sel…

### DIFF
--- a/src/features/render/hooks/useCanvasClickHandler.ts
+++ b/src/features/render/hooks/useCanvasClickHandler.ts
@@ -330,7 +330,7 @@ export function useCanvasClickHandler({
                         dispatchHighlighted(highlightActions.add([result.objectId]));
                     }
                 } else {
-                    if (alreadySelected) {
+                    if (alreadySelected && result.objectId === mainObject) {
                         dispatch(renderActions.setMainObject(undefined));
                         dispatch(renderActions.setStamp(null));
                         dispatchHighlighted(highlightActions.setIds([]));
@@ -346,7 +346,9 @@ export function useCanvasClickHandler({
                         currentSecondaryHighlightQuery.current = "";
                     } else {
                         dispatch(renderActions.setMainObject(result.objectId));
-                        dispatchHighlighted(highlightActions.setIds([result.objectId]));
+                        if (!alreadySelected) {
+                            dispatchHighlighted(highlightActions.setIds([result.objectId]));
+                        }
 
                         if ((!showPropertiesStamp && !secondaryHighlightProperty) || !db) {
                             return;


### PR DESCRIPTION
…ected (e.g. via model tree) and clicking on a non main selected object - don't unselect anything, just make this object main.

To unselect it - just click on it one more time.

https://trello.com/c/TkwTXH4s/797-selection-when-clicking-on-non-main-selected-object-in-single-selection-mode-make-object-main