### PR TITLE
Render: set default camera based on the project bounds

### DIFF
--- a/src/features/home/useResetView.ts
+++ b/src/features/home/useResetView.ts
@@ -1,18 +1,18 @@
-import { quat, vec3 } from "gl-matrix";
-
-import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { useAppDispatch } from "app/redux-store-interactions";
 import { hiddenActions, useDispatchHidden } from "contexts/hidden";
 import { highlightCollectionsActions, useDispatchHighlightCollections } from "contexts/highlightCollections";
 import { highlightActions, useDispatchHighlighted } from "contexts/highlighted";
 import { GroupStatus, objectGroupsActions, useDispatchObjectGroups, useLazyObjectGroups } from "contexts/objectGroups";
 import { selectionBasketActions, useDispatchSelectionBasket } from "contexts/selectionBasket";
-import { renderActions, selectHomeCameraPosition } from "features/render";
+import { renderActions } from "features/render";
 import { loadScene } from "features/render/utils";
 import { useSceneId } from "hooks/useSceneId";
 
+import { useDefaultCamera } from "../render/hooks/useDefaultCamera";
+
 export function useResetView() {
     const sceneId = useSceneId();
-    const homePos = useAppSelector(selectHomeCameraPosition);
+    const defaultCamera = useDefaultCamera();
     const dispatch = useAppDispatch();
     const dispatchHighlightCollections = useDispatchHighlightCollections();
     const dispatchHighlighted = useDispatchHighlighted();
@@ -32,14 +32,7 @@ export function useResetView() {
         try {
             const [{ url: _url, db: _db, ...sceneData }, camera] = await loadScene(sceneId);
             const groups = sceneData.objectGroups ?? [];
-            const initialCamera = resetCamera
-                ? camera ?? {
-                      kind: "pinhole",
-                      position: vec3.clone(homePos.position),
-                      rotation: quat.clone(homePos.rotation),
-                      fov: 60,
-                  }
-                : undefined;
+            const initialCamera = resetCamera ? camera ?? defaultCamera : undefined;
 
             dispatch(
                 renderActions.resetView({

--- a/src/features/render/hooks/useDefaultCamera.ts
+++ b/src/features/render/hooks/useDefaultCamera.ts
@@ -1,0 +1,17 @@
+import { useGetProjectQuery } from "apis/dataV2/dataV2Api";
+import { type CadCamera } from "features/render/types";
+import { useSceneId } from "hooks/useSceneId";
+
+import { getDefaultCamera } from "../utils";
+
+export function useDefaultCamera(): CadCamera | undefined {
+    const sceneId = useSceneId();
+    const { data: project } = useGetProjectQuery({ projectId: sceneId });
+
+    const bb = project?.bounds;
+    if (!bb) {
+        return;
+    }
+
+    return getDefaultCamera(bb);
+}

--- a/src/features/render/renderSlice.ts
+++ b/src/features/render/renderSlice.ts
@@ -18,18 +18,19 @@ import { VecRGB, VecRGBA } from "utils/color";
 import { mergeRecursive } from "utils/misc";
 
 import {
+    type CadCamera,
     CameraSpeedLevel,
-    CameraState,
-    CameraStep,
+    type CameraState,
+    type CameraStep,
     CameraType,
     ObjectVisibility,
     Picker,
-    SavedCameraPositions,
-    SceneConfig,
+    type SavedCameraPositions,
+    type SceneConfig,
     SelectionBasketMode,
-    Stamp,
-    Subtree,
-    Subtrees,
+    type Stamp,
+    type Subtree,
+    type Subtrees,
     SubtreeStatus,
 } from "./types";
 import { getLegacySubtrees, getSubtrees } from "./utils";
@@ -217,23 +218,13 @@ export const initScene = createAction<{
     tmZoneForCalc: string | undefined;
     sceneData: Omit<SceneConfig, "db" | "url">;
     sceneConfig: OctreeSceneConfig;
-    initialCamera: {
-        kind: "pinhole" | "orthographic";
-        position: vec3;
-        rotation: quat;
-        fov: number;
-    };
+    initialCamera: CadCamera;
     deviceProfile: RecursivePartial<State["deviceProfile"]>;
 }>("initScene");
 
 export const resetView = createAction<{
     sceneData: Omit<SceneConfig, "db" | "url">;
-    initialCamera?: {
-        kind: "pinhole" | "orthographic";
-        position: vec3;
-        rotation: quat;
-        fov: number;
-    };
+    initialCamera?: CadCamera;
 }>("resetView");
 
 export const selectBookmark = createAction(
@@ -790,8 +781,6 @@ export const selectCameraSpeedLevels = (state: RootState) => state.render.camera
 export const selectCurrentCameraSpeedLevel = (state: RootState) => state.render.currentCameraSpeedLevel;
 export const selectSavedCameraPositions = (state: RootState) =>
     state.render.savedCameraPositions as SavedCameraPositions;
-export const selectHomeCameraPosition = (state: RootState) =>
-    state.render.savedCameraPositions.positions[0] as CameraStep;
 export const selectSubtrees = (state: RootState) => state.render.subtrees;
 export const selectSelectionBasketMode = (state: RootState) => state.render.selectionBasketMode;
 export const selectSelectionBasketColor = (state: RootState) => state.render.selectionBasketColor;

--- a/src/features/render/utils.ts
+++ b/src/features/render/utils.ts
@@ -178,3 +178,30 @@ export function applyCameraDistanceToMeasureTolerance(
         segment: settings.segment ? settings.segment * hoverScale : undefined,
     };
 }
+
+export function getDefaultCamera(boundingBox?: [number, number, number, number]): CadCamera | undefined {
+    if (!boundingBox) {
+        return;
+    }
+
+    const centerX = (boundingBox[0] + boundingBox[2]) / 2;
+    const centerY = (boundingBox[1] + boundingBox[3]) / 2;
+    const width = boundingBox[2] - boundingBox[0];
+    const height = boundingBox[3] - boundingBox[1];
+
+    const fov = 60;
+    const maxDim = Math.max(width, height);
+    const distance = maxDim / (2 * Math.tan((fov * Math.PI) / 360));
+
+    const initPosition = vec3.fromValues(0, 0, distance);
+    const rotation = quat.fromValues(0.25000000000000006, 0.43301270189221935, 0.07945931129894554, 0.8623724356957945);
+    const rotatedPosition = vec3.transformQuat(vec3.create(), initPosition, rotation);
+    const position = vec3.fromValues(rotatedPosition[0] + centerX, rotatedPosition[1] + centerY, rotatedPosition[2]);
+
+    return {
+        kind: "pinhole",
+        position,
+        rotation,
+        fov,
+    };
+}


### PR DESCRIPTION
If there is no initial camera in the scene,
set the default camera based on the Project's bounding box with a default "side"perspective.

Fixes [this card](https://trello.com/c/FYF8RO4b).

Test scenes:
[Customer's scene](https://explorer.novorender.com/4922df9a36de45218654115bd773a0da) (camera set by customer)
[Test scene](https://explorer.novorender.com/af41085a8ae74f558d1f5f25f9c264ce) (same scene, no preset camera)