### PR TITLE
More granular explorer settings check in init

### DIFF
--- a/src/features/advancedSettings/advancedSettings.tsx
+++ b/src/features/advancedSettings/advancedSettings.tsx
@@ -328,7 +328,7 @@ function Root({ save, saving }: { save: () => Promise<void>; saving: boolean }) 
 
 function subtreesToHide(
     subtrees: Record<Subtree, SubtreeStatus>
-): NonNullable<CustomProperties["explorerProjectState"]>["renderSettings"]["hide"] {
+): NonNullable<NonNullable<CustomProperties["explorerProjectState"]>["renderSettings"]>["hide"] {
     return {
         terrain: subtrees.terrain === SubtreeStatus.Hidden,
         triangles: subtrees.triangles === SubtreeStatus.Hidden,

--- a/src/features/properties/slice.ts
+++ b/src/features/properties/slice.ts
@@ -58,13 +58,11 @@ export const propertiesSlice = createSlice({
         builder.addCase(initScene, (state, action) => {
             const props = action.payload.sceneData.customProperties;
 
-            if (props.explorerProjectState) {
-                state.stampSettings = props.explorerProjectState.features.properties.stamp;
+            if (props.explorerProjectState?.features?.properties?.starred) {
                 state.starred = Object.fromEntries(
                     props.explorerProjectState.features.properties.starred.map((prop) => [prop, true])
                 );
             } else if (props.properties) {
-                state.stampSettings = props.properties.stampSettings;
                 state.starred = Object.fromEntries(
                     props.properties.starred.map((prop: string) => [
                         ["path", "name"].includes(prop) ? capitalize(prop) : prop,
@@ -72,6 +70,11 @@ export const propertiesSlice = createSlice({
                     ])
                 );
             }
+
+            state.stampSettings =
+                props.explorerProjectState?.features?.properties?.stamp ??
+                props.properties?.stampSettings ??
+                state.stampSettings;
 
             state.showStamp = state.stampSettings.enabled;
         });

--- a/src/features/render/renderSlice.ts
+++ b/src/features/render/renderSlice.ts
@@ -517,7 +517,8 @@ export const renderSlice = createSlice({
 
             // corner features
             state.debugStats.enabled =
-                props.explorerProjectState?.features?.debugStats?.enabled ?? Boolean(props.showStats);
+                props.explorerProjectState?.features?.debugStats?.enabled ??
+                (Boolean(props.showStats) || state.debugStats.enabled);
             state.navigationCube.enabled =
                 !state.debugStats.enabled &&
                 (props.explorerProjectState?.features?.navigationCube?.enabled ?? Boolean(props.navigationCube));

--- a/src/features/render/renderSlice.ts
+++ b/src/features/render/renderSlice.ts
@@ -483,11 +483,8 @@ export const renderSlice = createSlice({
             state.deviceProfile = mergeRecursive(state.deviceProfile, deviceProfile);
             state.debugStats.enabled = window.location.search.includes("debug=true");
 
-            if (props.explorerProjectState) {
-                const { points, background, terrain, hide, ...advanced } = props.explorerProjectState.renderSettings;
-                points.size.metric = 0; //Variable that cannot be set on novoweb and have had 2 different default. Forcing to 0;
-                const { debugStats, navigationCube } = props.explorerProjectState.features;
-                const { highlights } = props.explorerProjectState;
+            // camera
+            if (props.explorerProjectState?.camera) {
                 const camera = props.explorerProjectState.camera;
 
                 state.cameraDefaults.pinhole = camera.pinhole;
@@ -495,47 +492,7 @@ export const renderSlice = createSlice({
                     state.cameraDefaults.orthographic,
                     camera.orthographic
                 );
-
-                state.background = mergeRecursive(state.background, {
-                    ...background,
-                    ...(!background.url ? { url: state.background.url, blur: state.background.blur } : {}),
-                });
-                state.points = mergeRecursive(state.points, points);
-                state.subtrees = getSubtrees(hide, sceneConfig.subtrees ?? ["triangles"]);
-                state.terrain = terrain;
-                state.terrain.elevationGradient = settings
-                    ? {
-                          knots: settings.terrain.elevationColors.map((node) => ({
-                              position: node.elevation,
-                              color: node.color,
-                          })),
-                      }
-                    : state.terrain.elevationGradient;
-                state.advanced = mergeRecursive(state.advanced, advanced);
-                state.debugStats.enabled = debugStats.enabled || state.debugStats.enabled;
-                state.navigationCube.enabled = !state.debugStats.enabled && navigationCube.enabled;
-                state.secondaryHighlight.property = highlights.secondary.property;
-            } else if (settings) {
-                // Legacy settings
-
-                // controls
-                if (props.flightFingerMap) {
-                    const { rotate, orbit, pan } = props.flightFingerMap;
-                    state.cameraDefaults.pinhole.controller =
-                        rotate === 1
-                            ? "flight"
-                            : orbit === 1
-                            ? pan === 2
-                                ? "cadRightPan"
-                                : "cadMiddlePan"
-                            : "special";
-                }
-
-                // corner features
-                state.debugStats.enabled = Boolean(props.showStats) || state.debugStats.enabled;
-                state.navigationCube.enabled = !state.debugStats.enabled && Boolean(props.navigationCube);
-
-                // camera
+            } else {
                 state.cameraDefaults.pinhole.clipping.far = Math.max(
                     (sceneData.camera as { far?: number })?.far ?? 0,
                     1000
@@ -556,9 +513,57 @@ export const renderSlice = createSlice({
                           fast: props.cameraSpeedLevels.flight.fast * 33,
                       }
                     : state.cameraDefaults.pinhole.speedLevels;
+            }
 
-                // highlight
-                state.secondaryHighlight.property = props.highlights?.secondary.property ?? "";
+            // corner features
+            state.debugStats.enabled =
+                props.explorerProjectState?.features?.debugStats?.enabled ?? Boolean(props.showStats);
+            state.navigationCube.enabled =
+                !state.debugStats.enabled &&
+                (props.explorerProjectState?.features?.debugStats?.enabled ?? Boolean(props.navigationCube));
+
+            // highlights
+            state.secondaryHighlight.property =
+                props.explorerProjectState?.highlights?.secondary.property ??
+                props.highlights?.secondary.property ??
+                "";
+
+            // render settings
+            if (props.explorerProjectState?.renderSettings) {
+                const { points, background, terrain, hide, ...advanced } = props.explorerProjectState.renderSettings;
+                points.size.metric = 0; //Variable that cannot be set on novoweb and have had 2 different default. Forcing to 0;
+
+                state.background = mergeRecursive(state.background, {
+                    ...background,
+                    ...(!background.url ? { url: state.background.url, blur: state.background.blur } : {}),
+                });
+                state.points = mergeRecursive(state.points, points);
+                state.subtrees = getSubtrees(hide, sceneConfig.subtrees ?? ["triangles"]);
+                state.terrain = terrain;
+                state.terrain.elevationGradient = settings
+                    ? {
+                          knots: settings.terrain.elevationColors.map((node) => ({
+                              position: node.elevation,
+                              color: node.color,
+                          })),
+                      }
+                    : state.terrain.elevationGradient;
+                state.advanced = mergeRecursive(state.advanced, advanced);
+            } else if (settings) {
+                // Legacy settings
+
+                // controls
+                if (props.flightFingerMap) {
+                    const { rotate, orbit, pan } = props.flightFingerMap;
+                    state.cameraDefaults.pinhole.controller =
+                        rotate === 1
+                            ? "flight"
+                            : orbit === 1
+                            ? pan === 2
+                                ? "cadRightPan"
+                                : "cadMiddlePan"
+                            : "special";
+                }
 
                 // background
                 state.background.color = settings.background.color ?? state.background.color;
@@ -629,7 +634,7 @@ export const renderSlice = createSlice({
                 (key) => state.subtrees[key as keyof State["subtrees"]] !== SubtreeStatus.Unavailable
             );
 
-            if (props.explorerProjectState) {
+            if (props.explorerProjectState?.renderSettings) {
                 const { points, background, terrain, hide } = props.explorerProjectState.renderSettings;
 
                 // background

--- a/src/features/render/renderSlice.ts
+++ b/src/features/render/renderSlice.ts
@@ -516,9 +516,9 @@ export const renderSlice = createSlice({
             }
 
             // corner features
-            state.debugStats.enabled =
-                props.explorerProjectState?.features?.debugStats?.enabled ??
-                (Boolean(props.showStats) || state.debugStats.enabled);
+            state.debugStats.enabled = props.explorerProjectState?.features?.debugStats
+                ? props.explorerProjectState.features.debugStats.enabled || state.debugStats.enabled
+                : Boolean(props.showStats) || state.debugStats.enabled;
             state.navigationCube.enabled =
                 !state.debugStats.enabled &&
                 (props.explorerProjectState?.features?.navigationCube?.enabled ?? Boolean(props.navigationCube));

--- a/src/features/render/renderSlice.ts
+++ b/src/features/render/renderSlice.ts
@@ -520,7 +520,7 @@ export const renderSlice = createSlice({
                 props.explorerProjectState?.features?.debugStats?.enabled ?? Boolean(props.showStats);
             state.navigationCube.enabled =
                 !state.debugStats.enabled &&
-                (props.explorerProjectState?.features?.debugStats?.enabled ?? Boolean(props.navigationCube));
+                (props.explorerProjectState?.features?.navigationCube?.enabled ?? Boolean(props.navigationCube));
 
             // highlights
             state.secondaryHighlight.property =

--- a/src/features/render/utils.ts
+++ b/src/features/render/utils.ts
@@ -9,7 +9,7 @@ import { CustomProperties } from "types/project";
 import { CadCamera, SceneConfig, Subtrees, SubtreeStatus } from "./types";
 
 export function getSubtrees(
-    hidden: NonNullable<CustomProperties["explorerProjectState"]>["renderSettings"]["hide"],
+    hidden: NonNullable<NonNullable<CustomProperties["explorerProjectState"]>["renderSettings"]>["hide"],
     subtrees: string[]
 ): Subtrees {
     return {

--- a/src/slices/explorer/slice.ts
+++ b/src/slices/explorer/slice.ts
@@ -261,25 +261,24 @@ export const explorerSlice = createSlice({
             }
             if (state.userRole !== UserRole.Viewer) {
                 state.enabledWidgets = uniqueArray(
-                    (customProperties.explorerProjectState
-                        ? (customProperties.explorerProjectState.features.widgets.enabled as WidgetKey[])
-                        : getEnabledFeatures(customProperties)
+                    (
+                        (customProperties.explorerProjectState?.features?.widgets?.enabled as WidgetKey[]) ??
+                        getEnabledFeatures(customProperties)
                     )
                         .concat(defaultEnabledAdminWidgets)
                         .concat(defaultEnabledWidgets)
                 );
             } else {
                 state.enabledWidgets = uniqueArray(
-                    (customProperties.explorerProjectState
-                        ? (customProperties.explorerProjectState.features.widgets.enabled as WidgetKey[]).filter(
-                              (key) => featuresConfig[key] && featuresConfig[key].type !== FeatureType.AdminWidget
-                          )
-                        : getEnabledFeatures(customProperties)
+                    (
+                        (customProperties.explorerProjectState?.features?.widgets?.enabled as WidgetKey[])?.filter(
+                            (key) => featuresConfig[key] && featuresConfig[key].type !== FeatureType.AdminWidget
+                        ) ?? getEnabledFeatures(customProperties)
                     ).concat(defaultEnabledWidgets)
                 );
             }
 
-            if (customProperties.explorerProjectState) {
+            if (customProperties.explorerProjectState?.features?.primaryMenu?.buttons) {
                 const [button1, button2, button3, button4, button5] = customProperties.explorerProjectState.features
                     .primaryMenu.buttons as ButtonKey[];
 
@@ -290,12 +289,15 @@ export const explorerSlice = createSlice({
                     button4,
                     button5,
                 };
+            } else {
+                state.primaryMenu = getPrimaryMenu(customProperties) ?? state.primaryMenu;
+            }
 
+            if (customProperties.explorerProjectState?.features?.contextMenus?.canvas.primary.features) {
                 const ctxMenuFeatures = customProperties.explorerProjectState.features.contextMenus.canvas.primary
                     .features as CanvasContextMenuFeatureKey[];
                 state.contextMenu.canvas.features = ctxMenuFeatures;
             } else {
-                state.primaryMenu = getPrimaryMenu(customProperties) ?? state.primaryMenu;
                 state.contextMenu.canvas.features =
                     getCanvasContextMenuFeatures(customProperties) ?? state.contextMenu.canvas.features;
             }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,5 +1,5 @@
 export type ExplorerProjectState = {
-    camera: {
+    camera?: {
         pinhole: {
             controller: "flight" | "special" | "cadRightPan" | "cadMiddlePan";
             clipping: {
@@ -30,7 +30,7 @@ export type ExplorerProjectState = {
             touchRotate?: boolean;
         };
     };
-    renderSettings: {
+    renderSettings?: {
         dynamicResolutionScaling: boolean;
         msaa: {
             enabled: boolean;
@@ -97,25 +97,25 @@ export type ExplorerProjectState = {
         };
     };
     features: {
-        widgets: {
+        widgets?: {
             enabled: string[];
         };
-        properties: {
+        properties?: {
             stamp: {
                 enabled: boolean;
             };
             starred: string[];
         };
-        navigationCube: {
+        navigationCube?: {
             enabled: boolean;
         };
-        debugStats: {
+        debugStats?: {
             enabled: boolean;
         };
-        primaryMenu: {
+        primaryMenu?: {
             buttons: string[];
         };
-        contextMenus: {
+        contextMenus?: {
             canvas: {
                 primary: {
                     features: string[];
@@ -123,7 +123,7 @@ export type ExplorerProjectState = {
             };
         };
     };
-    highlights: {
+    highlights?: {
         primary: {
             color: [number, number, number, number];
         };


### PR DESCRIPTION
https://trello.com/c/RhbOtt4X/805-project-with-only-copied-starred-properties-more-granular-check-for-explorer-settings-during-init

Project https://explorer.novorender.com/1108dcdda6c64cd987807d1085fdc536 should open

Currently in app init check for explorer settings is not granular - if explorer settings are presented - we assume that everything inside is also presented. But with new projects functionality people can create a new project and only copy few settings to it, so we have to check for specific properties inside explorer settings when initializing.