### PR TITLE
Forms: Bump max objects count to 5k

### DIFF
--- a/src/features/forms/routes/create/addObjects.tsx
+++ b/src/features/forms/routes/create/addObjects.tsx
@@ -13,7 +13,7 @@ import { AsyncState, AsyncStatus } from "types/misc";
 import { uniqueArray } from "utils/misc";
 import { searchDeepByPatterns } from "utils/search";
 
-const MAX_OBJECTS_COUNT = 2000;
+const MAX_OBJECTS_COUNT = 5000;
 
 export function AddObjects({
     onSave,


### PR DESCRIPTION
Fixes [this](https://trello.com/c/sYMNtEgI/1360-fob-cannot-create-forms-for-ifc-file) sales ops ticket.
They want to create forms for **2873** objects.
This is currently above our threshold of 2k.
I bumped threshold to **5k** as we're confident enough we can handle this amount (with some waiting times for the search).
 This is definitely better than not being able to create forms in the first place.