### PR TITLE
Forms: support for files upload

### DIFF
--- a/src/components/confirmation.tsx
+++ b/src/components/confirmation.tsx
@@ -8,6 +8,7 @@ export function Confirmation({
     onConfirm,
     loading,
     confirmBtnDisabled,
+    headerShadow = true,
     ...boxProps
 }: BoxProps & {
     title: string;
@@ -16,16 +17,19 @@ export function Confirmation({
     onConfirm?: () => void;
     loading?: boolean;
     confirmBtnDisabled?: boolean;
+    headerShadow?: boolean;
 }) {
     const theme = useTheme();
 
     return (
         <>
-            <Box
-                boxShadow={theme.customShadows.widgetHeader}
-                sx={{ height: 5, width: 1, mt: "-5px" }}
-                position="absolute"
-            />
+            {headerShadow && (
+                <Box
+                    boxShadow={theme.customShadows.widgetHeader}
+                    sx={{ height: 5, width: 1, mt: "-5px" }}
+                    position="absolute"
+                />
+            )}
             <Box
                 display="flex"
                 flexDirection="column"

--- a/src/components/imgModal.tsx
+++ b/src/components/imgModal.tsx
@@ -6,9 +6,10 @@ import { useEffect, useState } from "react";
 export const ImgModal = styled(
     ({
         src,
+        anonymous = false,
         Actions,
         ...props
-    }: Omit<ModalProps, "children"> & { src: string; Actions?: () => JSX.Element | null }) => {
+    }: Omit<ModalProps, "children"> & { src: string; anonymous?: boolean; Actions?: () => JSX.Element | null }) => {
         const [loading, setLoading] = useState(true);
 
         useEffect(() => {
@@ -31,7 +32,12 @@ export const ImgModal = styled(
                             <Close />
                         </IconButton>
                     )}
-                    <img onLoad={() => setLoading(false)} src={src} alt="" />
+                    <img
+                        onLoad={() => setLoading(false)}
+                        src={src}
+                        alt=""
+                        crossOrigin={anonymous ? "anonymous" : undefined}
+                    />
                     {Actions && !loading && (
                         <Box
                             sx={{

--- a/src/features/forms/addFilesButton.tsx
+++ b/src/features/forms/addFilesButton.tsx
@@ -1,0 +1,42 @@
+import { Box, Button, CircularProgress } from "@mui/material";
+import { type ChangeEventHandler, type DragEventHandler, type MouseEventHandler, useRef } from "react";
+
+interface AddFilesButtonProps {
+    accept: string;
+    multiple: boolean;
+    uploading: boolean;
+    disabled?: boolean;
+    onChange: ChangeEventHandler<HTMLInputElement>;
+}
+
+export default function AddFilesButton({
+    accept,
+    multiple,
+    onChange,
+    uploading,
+    disabled = false,
+}: AddFilesButtonProps) {
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const stopPropagation: DragEventHandler = (e) => {
+        e.preventDefault();
+    };
+
+    const handleAddFilesClick: MouseEventHandler = () => fileInputRef.current?.click();
+
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+        onChange(e);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+        }
+    };
+
+    return (
+        <Box display="flex" onDragOver={stopPropagation} onDrop={stopPropagation}>
+            <input type="file" ref={fileInputRef} onChange={handleChange} accept={accept} multiple={multiple} hidden />
+            <Button onClick={handleAddFilesClick} disabled={disabled || uploading} variant="contained">
+                {uploading ? <CircularProgress size={24} /> : `Add File${multiple ? "s" : ""}`}
+            </Button>
+        </Box>
+    );
+}

--- a/src/features/forms/api.ts
+++ b/src/features/forms/api.ts
@@ -1,4 +1,6 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi } from "@reduxjs/toolkit/query/react";
+
+import { getDataV2DynamicBaseQuery } from "apis/dataV2/utils";
 
 import {
     type Form,
@@ -13,7 +15,7 @@ import { calculateFormState } from "./utils";
 
 export const formsApi = createApi({
     reducerPath: "formsApi",
-    baseQuery: fetchBaseQuery({ baseUrl: "https://forms-fa-prod.azurewebsites.net/api/v1/" }),
+    baseQuery: getDataV2DynamicBaseQuery("/forms/"),
     tagTypes: ["Template", "Form", "Object"],
     keepUnusedDataFor: 60 * 5,
     endpoints: (builder) => ({

--- a/src/features/forms/api.ts
+++ b/src/features/forms/api.ts
@@ -1,6 +1,4 @@
-import { createApi } from "@reduxjs/toolkit/query/react";
-
-import { getDataV2DynamicBaseQuery } from "apis/dataV2/utils";
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import {
     type Form,
@@ -15,7 +13,7 @@ import { calculateFormState } from "./utils";
 
 export const formsApi = createApi({
     reducerPath: "formsApi",
-    baseQuery: getDataV2DynamicBaseQuery("/forms/"),
+    baseQuery: fetchBaseQuery({ baseUrl: "https://forms-fa-prod.azurewebsites.net/api/v1/" }),
     tagTypes: ["Template", "Form", "Object"],
     keepUnusedDataFor: 60 * 5,
     endpoints: (builder) => ({
@@ -200,15 +198,18 @@ export const formsApi = createApi({
             }),
             invalidatesTags: (_result, _error) => [{ type: "Template" as const, id: "ID_LIST" }],
         }),
-        uploadFiles: builder.mutation<void, { projectId: ProjectId; files: FileList }>({
-            query: ({ projectId, files }) => {
+        uploadFiles: builder.mutation<
+            { [key: string]: string },
+            { projectId: ProjectId; files: File[]; template?: boolean }
+        >({
+            query: ({ projectId, files, template = false }) => {
                 const filesData = new FormData();
                 for (const file of files) {
                     filesData.append(file.name, file);
                 }
                 return {
                     body: filesData,
-                    url: `projects/${projectId}/files`,
+                    url: `projects/${projectId}/files?template=${template}`,
                     method: "POST",
                     formData: true,
                 };

--- a/src/features/forms/api.ts
+++ b/src/features/forms/api.ts
@@ -200,6 +200,20 @@ export const formsApi = createApi({
             }),
             invalidatesTags: (_result, _error) => [{ type: "Template" as const, id: "ID_LIST" }],
         }),
+        uploadFiles: builder.mutation<void, { projectId: ProjectId; files: FileList }>({
+            query: ({ projectId, files }) => {
+                const filesData = new FormData();
+                for (const file of files) {
+                    filesData.append(file.name, file);
+                }
+                return {
+                    body: filesData,
+                    url: `projects/${projectId}/files`,
+                    method: "POST",
+                    formData: true,
+                };
+            },
+        }),
     }),
 });
 
@@ -217,4 +231,5 @@ export const {
     useDeleteLocationFormMutation,
     useDeleteTemplateMutation,
     useDeleteAllFormsMutation,
+    useUploadFilesMutation,
 } = formsApi;

--- a/src/features/forms/constants.ts
+++ b/src/features/forms/constants.ts
@@ -1,0 +1,1 @@
+export const FILE_SIZE_LIMIT = 200; // MB

--- a/src/features/forms/routes/create/addFormItem.tsx
+++ b/src/features/forms/routes/create/addFormItem.tsx
@@ -1,63 +1,134 @@
+import { Delete, InfoOutlined } from "@mui/icons-material";
 import {
     Autocomplete,
     Box,
     Button,
+    ButtonGroup,
     Checkbox,
     Chip,
+    CircularProgress,
     FormControl,
     FormControlLabel,
     FormGroup,
     FormLabel,
+    IconButton,
+    InputLabel,
+    List,
+    ListItem,
+    ListItemText,
+    MenuItem,
     Radio,
     RadioGroup,
+    Select,
     Typography,
 } from "@mui/material";
-import { FormEventHandler, useCallback, useMemo, useState } from "react";
+import {
+    ChangeEvent,
+    DragEventHandler,
+    FormEventHandler,
+    MouseEventHandler,
+    useCallback,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import { useHistory } from "react-router-dom";
 
-import { Divider, ScrollBox, TextArea, TextField } from "components";
+import { Divider, ScrollBox, TextArea, TextField, Tooltip } from "components";
+import { useUploadFilesMutation } from "features/forms/api";
+import { useSceneId } from "hooks/useSceneId";
 import { useToggle } from "hooks/useToggle";
 
-import { FormItem, FormItemType } from "../../types";
+import { type FileTypes, type FormItem, FormItemType } from "../../types";
+
+const DOC_TYPES = [
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+];
 
 export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
+    const sceneId = useSceneId();
     const history = useHistory();
     const [title, setTitle] = useState("");
     const [value, setValue] = useState("");
     const [type, setType] = useState(FormItemType.Checkbox);
     const [relevant, toggleRelevant] = useToggle(true);
-    const [options, setOptions] = useState([] as string[]);
+    const [options, setOptions] = useState<string[]>([]);
+    const [files, setFiles] = useState<(File & { checksum?: string })[]>([]);
+    const [fileTypes, setFileTypes] = useState<FileTypes>([]);
+    const [multiple, toggleMultiple] = useToggle(true);
+    const [readonly, toggleReadonly] = useToggle(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const [uploadFiles, { isLoading: areFilesUploading }] = useUploadFilesMutation();
+
+    const accept = useMemo(() => {
+        let mimeTypes = fileTypes.includes("Images") ? "image/*," : "";
+        if (fileTypes.includes("Documents")) {
+            mimeTypes += DOC_TYPES.join(",");
+        }
+        return mimeTypes;
+    }, [fileTypes]);
 
     const canSave = useMemo(
         () =>
             title.trim() &&
             ([FormItemType.Input, FormItemType.YesNo, FormItemType.TrafficLight].includes(type) ||
                 ([FormItemType.Checkbox, FormItemType.Dropdown].includes(type) && options.length) ||
-                (type === FormItemType.Text && value.trim().length)),
-        [title, type, options, value]
+                (type === FormItemType.Text && value.trim().length) ||
+                (type === FormItemType.File && (!readonly || files.length))),
+        [title, type, options.length, value, readonly, files.length]
     );
 
     const handleSubmit = useCallback<FormEventHandler>(
-        (e) => {
+        async (e) => {
             e.preventDefault();
 
             if (!canSave) {
                 return;
             }
 
+            if (FormItemType.File && files.length) {
+                const result = await uploadFiles({ projectId: sceneId, files, template: true });
+                if ("data" in result) {
+                    files.forEach((file) => (file.checksum = result.data[file.name]));
+                }
+            }
+
             const newItem: FormItem = {
                 id: window.crypto.randomUUID(),
                 title,
                 type,
-                value: type === FormItemType.Text ? [value] : undefined,
+                value: type === FormItemType.Text ? [value] : type === FormItemType.File ? files : undefined,
                 required: type !== FormItemType.Text && relevant,
                 ...(type === FormItemType.Checkbox || type === FormItemType.Dropdown ? { options } : {}),
+                ...(type === FormItemType.File && { accept, multiple, readonly }),
             } as FormItem;
 
             onSave(newItem);
             history.goBack();
         },
-        [canSave, title, type, relevant, options, onSave, history, value]
+        [
+            canSave,
+            files,
+            title,
+            type,
+            value,
+            relevant,
+            options,
+            accept,
+            multiple,
+            readonly,
+            onSave,
+            history,
+            uploadFiles,
+            sceneId,
+        ]
     );
 
     const handleTitleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value), []);
@@ -71,6 +142,36 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
     );
     const handleOptionsChange = useCallback((_: React.SyntheticEvent, value: string[]) => setOptions(value), []);
     const handleTextChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => setValue(e.target.value), []);
+    const handleToggleMultiple = useCallback(
+        (_: React.ChangeEvent<HTMLInputElement>) => toggleMultiple(),
+        [toggleMultiple]
+    );
+    const handleToggleReadonly = useCallback(
+        (_: React.ChangeEvent<HTMLInputElement>) => toggleReadonly(),
+        [toggleReadonly]
+    );
+
+    const handleDragOver: DragEventHandler = (e) => {
+        e.preventDefault();
+    };
+
+    const handleFileDrop: DragEventHandler = (e) => {
+        e.preventDefault();
+    };
+
+    const handleFilesChange = async (e: ChangeEvent<HTMLInputElement>) => {
+        const files = e.target.files;
+        if (!files || !files.length) {
+            return;
+        }
+        setFiles((prevFiles) => [...prevFiles, ...files]);
+    };
+
+    const handleAddFilesClick: MouseEventHandler = () => fileInputRef.current?.click();
+
+    const handleRemoveFile = (file: File) => {
+        setFiles((prevFiles) => prevFiles.filter((f) => f.name !== file.name));
+    };
 
     return (
         <ScrollBox p={1} pt={2} pb={3} component="form" onSubmit={handleSubmit}>
@@ -93,7 +194,7 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
                 />
             </FormGroup>
             <Divider sx={{ my: 1 }} />
-            <FormControl>
+            <FormControl sx={{ mb: 1 }}>
                 <FormLabel sx={{ fontWeight: 600, color: "text.primary" }} id="form-item-type">
                     Type
                 </FormLabel>
@@ -113,7 +214,30 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
                     />
                     <FormControlLabel value={FormItemType.Dropdown} control={<Radio size="small" />} label="Dropdown" />
                     <FormControlLabel value={FormItemType.Input} control={<Radio size="small" />} label="Input" />
-                    <FormControlLabel value={FormItemType.Text} control={<Radio size="small" />} label="Text or URL" />
+                    <FormControlLabel
+                        value={FormItemType.Text}
+                        control={<Radio size="small" />}
+                        label={
+                            <>
+                                Text or URL
+                                <Tooltip
+                                    title={
+                                        'This is an immutable item. It will not be editable or clearable when filling the form. If you require an item that can be modified, please use the "Input" item instead.'
+                                    }
+                                    enterDelay={0}
+                                >
+                                    <IconButton
+                                        onClick={(evt) => {
+                                            evt.stopPropagation();
+                                        }}
+                                    >
+                                        <InfoOutlined />
+                                    </IconButton>
+                                </Tooltip>
+                            </>
+                        }
+                    />
+                    <FormControlLabel value={FormItemType.File} control={<Radio size="small" />} label="File" />
                 </RadioGroup>
             </FormControl>
             {[FormItemType.Checkbox, FormItemType.Dropdown].includes(type) && (
@@ -146,6 +270,89 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
                         value={value}
                         onChange={handleTextChange}
                     />
+                </>
+            )}
+            {type === FormItemType.File && (
+                <>
+                    <Divider sx={{ mb: 2 }} />
+                    <FormControl size="small" sx={{ width: 1, mb: 1 }}>
+                        <InputLabel id="forms-files-accept-label">Accept file types</InputLabel>
+                        <Select
+                            labelId="forms-files-accept-label"
+                            id="forms-files-accept"
+                            fullWidth
+                            multiple
+                            value={fileTypes}
+                            onChange={(e) => setFileTypes(e.target.value as FileTypes)}
+                            name="accept"
+                            label="Accept file types"
+                        >
+                            {["Documents", "Images"].map((fileType) => (
+                                <MenuItem
+                                    key={fileType}
+                                    value={fileType}
+                                    sx={{
+                                        fontWeight: (fileTypes as string[]).includes(fileType) ? "bold" : "regular",
+                                    }}
+                                >
+                                    {fileType}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                    <FormGroup>
+                        <FormControlLabel
+                            control={<Checkbox size="small" checked={multiple} onChange={handleToggleMultiple} />}
+                            label="Select multiple files"
+                        />
+                        <FormControlLabel
+                            control={<Checkbox size="small" checked={!readonly} onChange={handleToggleReadonly} />}
+                            label="Allow changing files"
+                            sx={{ mb: 1 }}
+                        />
+                        <Box display="flex" onDragOver={handleDragOver} onDrop={handleFileDrop}>
+                            <input
+                                type="file"
+                                ref={fileInputRef}
+                                onChange={handleFilesChange}
+                                accept={accept}
+                                multiple={multiple}
+                                hidden
+                            />
+                            <ButtonGroup variant="contained" disabled={areFilesUploading}>
+                                <Button onClick={handleAddFilesClick}>
+                                    {areFilesUploading ? (
+                                        <CircularProgress size={24} />
+                                    ) : (
+                                        `Add File${multiple ? "s" : ""}`
+                                    )}
+                                </Button>
+                            </ButtonGroup>
+                        </Box>
+                    </FormGroup>
+                    <List
+                        dense
+                        sx={{
+                            width: "100%",
+                            bgcolor: "background.paper",
+                            position: "relative",
+                            overflow: "auto",
+                            mb: 1,
+                        }}
+                    >
+                        {files.map((file) => (
+                            <ListItem
+                                key={file.name}
+                                secondaryAction={
+                                    <IconButton edge="end" aria-label="delete" onClick={() => handleRemoveFile(file)}>
+                                        <Delete />
+                                    </IconButton>
+                                }
+                            >
+                                <ListItemText primary={file.name} />
+                            </ListItem>
+                        ))}
+                    </List>
                 </>
             )}
             <Box display="flex" justifyContent="space-between" mt={2}>

--- a/src/features/forms/routes/create/addFormItem.tsx
+++ b/src/features/forms/routes/create/addFormItem.tsx
@@ -30,7 +30,7 @@ import { FILE_SIZE_LIMIT } from "features/forms/constants";
 import { useSceneId } from "hooks/useSceneId";
 import { useToggle } from "hooks/useToggle";
 
-import { type FileTypes, type FormFileUploadResponce, type FormItem, FormItemType } from "../../types";
+import { type FileTypes, type FormFileUploadResponse, type FormItem, FormItemType } from "../../types";
 
 const DOC_TYPES = [
     "application/pdf",
@@ -50,7 +50,7 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
     const [type, setType] = useState(FormItemType.Checkbox);
     const [relevant, toggleRelevant] = useToggle(true);
     const [options, setOptions] = useState<string[]>([]);
-    const [files, setFiles] = useState<(File & FormFileUploadResponce)[]>([]);
+    const [files, setFiles] = useState<(File & FormFileUploadResponse)[]>([]);
     const [fileTypes, setFileTypes] = useState<FileTypes>([]);
     const [multiple, toggleMultiple] = useToggle(true);
     const [readonly, toggleReadonly] = useToggle(false);
@@ -88,8 +88,8 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
                 const result = await uploadFiles({ projectId: sceneId, files, template: true });
                 if ("data" in result) {
                     files.forEach((file) => {
-                        file.checksum = (result.data[file.name] as FormFileUploadResponce)?.checksum;
-                        file.url = (result.data[file.name] as FormFileUploadResponce)?.url;
+                        file.checksum = (result.data[file.name] as FormFileUploadResponse)?.checksum;
+                        file.url = (result.data[file.name] as FormFileUploadResponse)?.url;
                     });
                 }
             }
@@ -171,7 +171,7 @@ export function AddFormItem({ onSave }: { onSave: (item: FormItem) => void }) {
             <Alert severity={type === FormItemType.File ? "warning" : "info"} sx={{ mt: 1 }}>
                 {type === FormItemType.File
                     ? "This item type is in BETA."
-                    : 'This is an immutable item. It will not be editable or clearable when filling the form. If you require an tem that can be modified, please use the "Input" item instead.'}
+                    : 'This is an immutable item. It will not be editable or clearable when filling the form. If you require an item that can be modified, please use the "Input" item instead.'}
             </Alert>
         );
 

--- a/src/features/forms/routes/instance/formItem.tsx
+++ b/src/features/forms/routes/instance/formItem.tsx
@@ -1,4 +1,4 @@
-import { NotInterested, OpenInNew } from "@mui/icons-material";
+import { Close, NotInterested, OpenInNew } from "@mui/icons-material";
 import {
     Box,
     Checkbox,
@@ -13,16 +13,35 @@ import {
     Radio,
     RadioGroup,
     Select,
+    Snackbar,
     Typography,
     useTheme,
 } from "@mui/material";
-import { type Dispatch, type MouseEvent, type SetStateAction, useState } from "react";
+import {
+    ChangeEvent,
+    type Dispatch,
+    FormEvent,
+    type MouseEvent,
+    type SetStateAction,
+    useCallback,
+    useState,
+} from "react";
 import { FixedSizeList } from "react-window";
 
-import { ImgModal, withCustomScrollbar } from "components";
+import { Confirmation, ImgModal, withCustomScrollbar } from "components";
+import AddFilesButton from "features/forms/addFilesButton";
+import { useUploadFilesMutation } from "features/forms/api";
+import { FILE_SIZE_LIMIT } from "features/forms/constants";
+import { useSceneId } from "hooks/useSceneId";
 import { useToggle } from "hooks/useToggle";
 
-import { type FormItem, FormItemType } from "../../types";
+import {
+    type FileItem as FileItemType,
+    type FormFileUploadResponce,
+    type FormItem,
+    FormItemType,
+    type FormsFile,
+} from "../../types";
 import FileItem from "./formItems/fileItem";
 
 // Based on https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -94,9 +113,13 @@ const FormItemHeader = ({ item, toggleRelevant }: { item: FormItem; toggleReleva
 );
 
 export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatch<SetStateAction<FormItem[]>> }) {
+    const sceneId = useSceneId();
     const theme = useTheme();
+    const [uploadFiles, { isLoading: uploading }] = useUploadFilesMutation();
 
     const [modalOpen, toggleModal] = useToggle();
+    const [fileSizeWarning, toggleFileSizeWarning] = useToggle(false);
+    const [isDeletingFile, setIsDeletingFile] = useState<number | null>(null);
     const [editing, setEditing] = useState(false);
     const [isRelevant, setIsRelevant] = useState(item.required);
     const [activeImage, setActiveImage] = useState("");
@@ -105,12 +128,9 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
         if (!editing) {
             setEditing(true);
         }
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         setItems((state) =>
             state.map((_item) =>
-                _item === item
+                (_item as Exclude<FormItem, FileItemType>) === item
                     ? {
                           ...item,
                           value: value ? [value] : null,
@@ -124,15 +144,12 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
         const relevant = item.required ? true : !isRelevant;
         setIsRelevant(relevant);
         setEditing(relevant);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         setItems((state) =>
             state.map((_item) =>
                 _item === item
                     ? {
                           ...item,
                           relevant,
-                          value: item.value ?? null,
                       }
                     : _item
             )
@@ -154,39 +171,77 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
         setEditing(false);
     };
 
-    // const handleFileUpload = (event) => {
-    //     const newFiles = Array.from(event.target.files).map((file) => ({
-    //         ...file,
-    //         checksum: calculateChecksum(file),
-    //         url: URL.createObjectURL(file),
-    //     }));
-    //     const updatedValue = [...(item.value || []), ...newFiles];
-    //     handleChange(updatedValue);
-    //     event.target.value = null; // Clear the input field
-    // };
+    const handleFileUpload = async (e: ChangeEvent<HTMLInputElement>, itemId: string) => {
+        const files: FormsFile[] = Array.from(e.target.files ?? []);
+        if (files.length === 0) {
+            return;
+        }
 
-    // const handleRemoveFile = (index) => {
-    //     const updatedValue = [...item.value];
-    //     updatedValue.splice(index, 1);
-    //     handleChange(updatedValue);
-    // };
+        let showFileSizeWarning = false;
+        const filteredFiles = files.filter((file) => {
+            if (file.size > FILE_SIZE_LIMIT * 1024 * 1024) {
+                showFileSizeWarning = true;
+                return false;
+            }
+            return true;
+        });
 
-    const handleRemoveFile = (index: number) => {
-        // setItems((state: FormItem[]) =>
-        //     state.map((_item) =>
-        //         _item === item
-        //             ? {
-        //                   ...item,
-        //                   value: item.value?.filter((_, i) => i !== index),
-        //               }
-        //             : _item
-        //     )
-        // );
+        toggleFileSizeWarning(showFileSizeWarning);
+
+        if (filteredFiles.length === 0) {
+            return;
+        }
+
+        const resp = await uploadFiles({ projectId: sceneId, files: filteredFiles, template: false });
+        if ("data" in resp) {
+            filteredFiles.forEach((file) => {
+                if (resp.data[file.name]) {
+                    file.checksum = (resp.data[file.name] as FormFileUploadResponce)?.checksum;
+                    file.url = (resp.data[file.name] as FormFileUploadResponce)?.url;
+                }
+            });
+        }
+
+        setItems((state) =>
+            state.map((item) => {
+                if (item.id === itemId) {
+                    return item.type === FormItemType.File
+                        ? ({
+                              ...item,
+                              value: [...(item.value ?? []), ...(filteredFiles as { checksum?: string }[])].filter(
+                                  (file, idx, arr) => idx === arr.findIndex((f) => f.checksum === file.checksum)
+                              ),
+                          } as FileItemType)
+                        : item;
+                }
+                return item;
+            })
+        );
     };
 
-    // const calculateChecksum = (file) => {
-    //     return `${file.size}-${file.lastModified}`;
-    // };
+    const handleRemoveFile = useCallback((item: FileItemType, index: number) => {
+        setIsDeletingFile(index);
+    }, []);
+
+    const deleteFile = useCallback(
+        (e: FormEvent) => {
+            e.preventDefault();
+            if (Number.isInteger(isDeletingFile) && item.type === FormItemType.File) {
+                setItems((state) =>
+                    state.map((_item) =>
+                        _item.id === item.id
+                            ? ({
+                                  ..._item,
+                                  value: (_item.value as FormsFile[]).filter((_, index) => index !== isDeletingFile),
+                              } as FileItemType)
+                            : _item
+                    )
+                );
+            }
+            setIsDeletingFile(null);
+        },
+        [isDeletingFile, item, setItems]
+    );
 
     const openImageModal = async (url: string = "") => {
         setActiveImage(url);
@@ -345,13 +400,23 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
 
         case FormItemType.File:
             return (
-                <FormControl disabled={!item.required && !item.relevant} component="fieldset" fullWidth>
+                <FormControl fullWidth>
                     <FormItemHeader item={item} toggleRelevant={toggleRelevant} />
-                    {item.value && item.value.length > 0 ? (
+                    {Number.isInteger(isDeletingFile) ? (
+                        <Confirmation
+                            title={`Delete file "${(item.value as FormsFile[])[isDeletingFile as number].name}"?`}
+                            confirmBtnText="Delete"
+                            onCancel={() => setIsDeletingFile(null)}
+                            component="form"
+                            onSubmit={deleteFile}
+                            headerShadow={false}
+                        />
+                    ) : item.value && !!item.value.length ? (
                         <StyledFixedSizeList
                             style={{
                                 paddingLeft: theme.spacing(1),
                                 paddingRight: theme.spacing(1),
+                                marginBottom: theme.spacing(1),
                             }}
                             height={item.value.length * 80}
                             width="100%"
@@ -363,27 +428,49 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
                                 <FileItem
                                     style={style}
                                     file={item.value![index]}
-                                    isReadonly={item.readonly}
+                                    isReadonly={item.readonly || !isRelevant}
                                     activeImage={activeImage}
                                     isModalOpen={modalOpen}
-                                    index={index}
-                                    removeFile={handleRemoveFile}
+                                    removeFile={() => handleRemoveFile(item, index)}
                                     openImageModal={openImageModal}
                                 />
                             )}
                         </StyledFixedSizeList>
                     ) : (
-                        <Typography variant="body2">No files uploaded</Typography>
+                        <Typography variant="body2" my={1}>
+                            No files uploaded.
+                        </Typography>
                     )}
-                    {/* <input
-                            type="file"
-                            multiple={item.multiple}
-                            accept={item.accept}
-                            // directory={item.dirrectory ? "directory" : undefined}
-                            // webkitdirectory={item.dirrectory ? "webkitdirectory" : undefined}
-                            onChange={handleFileUpload}
-                        /> */}
+                    <AddFilesButton
+                        accept={item.accept}
+                        multiple={item.multiple}
+                        onChange={(e) => handleFileUpload(e, item.id!)}
+                        uploading={uploading}
+                        disabled={!isRelevant}
+                    />
                     <ImgModal src={activeImage ?? ""} open={modalOpen} onClose={() => toggleModal()} anonymous />
+                    <Snackbar
+                        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+                        sx={{
+                            width: { xs: "auto", sm: 350 },
+                            bottom: { xs: "auto", sm: 24 },
+                            top: { xs: 24, sm: "auto" },
+                        }}
+                        autoHideDuration={2500}
+                        open={fileSizeWarning}
+                        onClose={() => toggleFileSizeWarning(false)}
+                        message={`Some files were not added because they are larger than ${FILE_SIZE_LIMIT} MB.`}
+                        action={
+                            <IconButton
+                                size="small"
+                                aria-label="close"
+                                color="inherit"
+                                onClick={() => toggleFileSizeWarning(false)}
+                            >
+                                <Close fontSize="small" />
+                            </IconButton>
+                        }
+                    />
                 </FormControl>
             );
 

--- a/src/features/forms/routes/instance/formItem.tsx
+++ b/src/features/forms/routes/instance/formItem.tsx
@@ -13,8 +13,12 @@ import {
     Radio,
     RadioGroup,
     Select,
+    Typography,
 } from "@mui/material";
 import { type Dispatch, type MouseEvent, type SetStateAction, useState } from "react";
+
+import { ImgModal } from "components";
+import { useToggle } from "hooks/useToggle";
 
 import { type FormItem, FormItemType } from "../../types";
 
@@ -85,13 +89,18 @@ const FormItemHeader = ({ item, toggleRelevant }: { item: FormItem; toggleReleva
 );
 
 export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatch<SetStateAction<FormItem[]>> }) {
+    const [modalOpen, toggleModal] = useToggle();
     const [editing, setEditing] = useState(false);
     const [isRelevant, setIsRelevant] = useState(item.required);
+    const [activeImage, setActiveImage] = useState("");
 
     const handleChange = (value: string) => {
         if (!editing) {
             setEditing(true);
         }
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         setItems((state) =>
             state.map((_item) =>
                 _item === item
@@ -108,6 +117,8 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
         const relevant = item.required ? true : !isRelevant;
         setIsRelevant(relevant);
         setEditing(relevant);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         setItems((state) =>
             state.map((_item) =>
                 _item === item
@@ -134,6 +145,32 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
 
     const handleTextFieldBlur = () => {
         setEditing(false);
+    };
+
+    // const handleFileUpload = (event) => {
+    //     const newFiles = Array.from(event.target.files).map((file) => ({
+    //         ...file,
+    //         checksum: calculateChecksum(file),
+    //         url: URL.createObjectURL(file),
+    //     }));
+    //     const updatedValue = [...(item.value || []), ...newFiles];
+    //     handleChange(updatedValue);
+    //     event.target.value = null; // Clear the input field
+    // };
+
+    // const handleRemoveFile = (index) => {
+    //     const updatedValue = [...item.value];
+    //     updatedValue.splice(index, 1);
+    //     handleChange(updatedValue);
+    // };
+
+    // const calculateChecksum = (file) => {
+    //     return `${file.size}-${file.lastModified}`;
+    // };
+
+    const handleThumbnailClick = async (url: string = "") => {
+        setActiveImage(url);
+        toggleModal();
     };
 
     switch (item.type) {
@@ -283,6 +320,71 @@ export function FormItem({ item, setItems }: { item: FormItem; setItems: Dispatc
                             </Box>
                         ))}
                     </Box>
+                </FormControl>
+            );
+
+        case FormItemType.File:
+            console.log(item);
+            return (
+                <FormControl
+                    // disabled={!item.required && !item.relevant}
+                    component="fieldset"
+                    fullWidth
+                >
+                    {/* <FormItemHeader item={item} toggleRelevant={toggleRelevant} /> */}
+                    <div>
+                        {item.value && item.value.length > 0 ? (
+                            <div>
+                                {item.value.map((file, index) => (
+                                    <div key={index}>
+                                        {file.type.startsWith("image/") ? (
+                                            <Box
+                                                sx={{
+                                                    mb: 1,
+                                                    "& > img": {
+                                                        width: "100%",
+                                                        maxHeight: 150,
+                                                        maxWidth: "60%",
+                                                        objectFit: "cover",
+                                                        cursor: "pointer",
+                                                    },
+                                                }}
+                                            >
+                                                <img
+                                                    onClick={() => handleThumbnailClick(file.url)}
+                                                    src={file.url}
+                                                    alt={file.name}
+                                                    crossOrigin="anonymous"
+                                                />
+                                            </Box>
+                                        ) : file.type === "application/pdf" ? (
+                                            <Box marginY={1}>
+                                                <Link href={file.url} target="_blank" rel="noopener noreferrer">
+                                                    {file.name}
+                                                    <OpenInNew fontSize="small" style={{ marginLeft: "5px" }} />
+                                                </Link>
+                                            </Box>
+                                        ) : (
+                                            <Box marginY={1}>{file.name}</Box>
+                                        )}
+                                        {/* <Button onClick={() => handleRemoveFile(index)}>Remove</Button> */}
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <Typography variant="body2">No files uploaded</Typography>
+                        )}
+                        {/* <input
+                            type="file"
+                            multiple={item.multiple}
+                            accept={item.accept}
+                            // directory={item.dirrectory ? "directory" : undefined}
+                            // webkitdirectory={item.dirrectory ? "webkitdirectory" : undefined}
+                            onChange={handleFileUpload}
+                        /> */}
+
+                        <ImgModal src={activeImage ?? ""} open={modalOpen} onClose={() => toggleModal()} anonymous />
+                    </div>
                 </FormControl>
             );
 

--- a/src/features/forms/routes/instance/formItems/fileItem.tsx
+++ b/src/features/forms/routes/instance/formItems/fileItem.tsx
@@ -1,0 +1,229 @@
+import { Delete, Download, FilePresentOutlined, MoreVert, PictureAsPdfOutlined } from "@mui/icons-material";
+import {
+    Box,
+    css,
+    IconButton,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    styled,
+    useTheme,
+} from "@mui/material";
+import { CSSProperties, type MouseEvent, useState } from "react";
+
+import { Tooltip } from "components";
+
+export interface FileItemProps {
+    style: CSSProperties;
+    file: File & {
+        checksum?: string | undefined;
+        url?: string | undefined;
+    };
+    isReadonly: boolean;
+    activeImage: string;
+    isModalOpen: boolean;
+    index: number;
+    removeFile: (index: number) => void;
+    openImageModal: (url?: string) => void;
+}
+
+const Img = styled("img")(
+    () => css`
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+        display: block;
+    `
+);
+
+export default function FileItem({
+    style,
+    file,
+    isReadonly,
+    activeImage,
+    isModalOpen,
+    index,
+    removeFile,
+    openImageModal,
+}: FileItemProps) {
+    const theme = useTheme();
+
+    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+
+    const stopPropagation = (evt: MouseEvent | FocusEvent) => {
+        evt.stopPropagation();
+    };
+
+    const openMenu = (evt: MouseEvent<HTMLButtonElement>) => {
+        stopPropagation(evt);
+        setMenuAnchor(evt.currentTarget);
+    };
+
+    const closeMenu = () => {
+        setMenuAnchor(null);
+    };
+
+    const isImage = /^image\//.test(file.type);
+    const isPdf = /^application\/pdf$/.test(file.type);
+    const icon = isImage ? (
+        <Img src={file.url} alt={file.name} crossOrigin="anonymous" />
+    ) : isPdf ? (
+        <PictureAsPdfOutlined sx={{ width: 50, height: 50 }} />
+    ) : (
+        <FilePresentOutlined sx={{ width: 50, height: 50 }} />
+    );
+
+    const handleFileClick = () => {
+        if (isImage) {
+            openImageModal(file.url);
+        } else if (isPdf) {
+            window.open(file.url, "_blank");
+        } else {
+            downloadFile(file);
+        }
+    };
+
+    const handleRemoveFile = () => {
+        removeFile(index);
+    };
+
+    return (
+        <ListItemButton
+            style={style}
+            onClick={handleFileClick}
+            sx={{
+                padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+                background: isModalOpen && file.url === activeImage ? theme.palette.grey[300] : "",
+            }}
+        >
+            <Box width={1} maxHeight={70} height={70} display="flex" alignItems="flex-start" overflow="hidden">
+                <ListItemIcon>
+                    <Box
+                        display="flex"
+                        justifyContent="center"
+                        alignItems="center"
+                        sx={{
+                            position: "relative",
+                            "&::before": {
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                borderRadius: "2px",
+                                px: 1,
+                                py: 0.5,
+                                color: "common.white",
+                                fontSize: "10px",
+                                fontWeight: 600,
+                                content: `"${formatFileSize(file.size)}"`,
+                                backgroundColor: "secondary.main",
+                            },
+                        }}
+                        bgcolor={theme.palette.grey[200]}
+                        height={70}
+                        width={100}
+                        flexShrink={0}
+                        flexGrow={0}
+                    >
+                        {icon}
+                    </Box>
+                </ListItemIcon>
+                <ListItemText
+                    sx={{ ml: 1 }}
+                    primary={
+                        <Tooltip disableInteractive title={file.name}>
+                            <Box>{file.name}</Box>
+                        </Tooltip>
+                    }
+                    primaryTypographyProps={{
+                        noWrap: true,
+                        variant: "body1",
+                        color: isPdf ? "primary" : "default",
+                        sx: { fontWeight: 600, mb: 1, textDecoration: isPdf ? "underline" : "none" },
+                    }}
+                    secondary={formatLastModified(file.lastModified)}
+                />
+            </Box>
+            <IconButton
+                color={menuAnchor ? "primary" : "default"}
+                size="small"
+                aria-haspopup="true"
+                sx={{ p: 0, height: 70 }}
+                disableRipple
+                onClick={openMenu}
+            >
+                <MoreVert />
+            </IconButton>
+            <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClick={stopPropagation} onClose={closeMenu}>
+                <MenuItem onClick={() => downloadFile(file)}>
+                    <Download fontSize="small" />
+                    <ListItemText primary="Download" />
+                </MenuItem>
+                {!isReadonly && (
+                    <MenuItem onClick={handleRemoveFile}>
+                        <Delete fontSize="small" />
+                        <ListItemText primary="Remove" />
+                    </MenuItem>
+                )}
+            </Menu>
+        </ListItemButton>
+    );
+}
+
+function formatFileSize(bytes: number): string {
+    const units = ["Bytes", "KB", "MB", "GB", "TB", "PB"];
+    if (bytes === 0) {
+        return "0 Bytes";
+    }
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const size = bytes / Math.pow(1024, i);
+    return `${size.toFixed(2)} ${units[i]}`;
+}
+
+function formatLastModified(timestamp: number): string {
+    const date = new Date(timestamp);
+    const options: Intl.DateTimeFormatOptions = {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: true,
+    };
+    return date.toLocaleString(window.navigator.language, options);
+}
+
+async function downloadFile(
+    file: File & {
+        checksum?: string | undefined;
+        url?: string | undefined;
+    }
+) {
+    if (file.url) {
+        try {
+            const resp = await fetch(file.url);
+
+            if (!resp.ok) {
+                throw new Error(`Failed to download ${file.name}`);
+            }
+
+            const blob = await resp.blob();
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = file.name;
+
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode?.removeChild(link);
+
+            window.URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error(error);
+        }
+    } else {
+        console.error("File URL is not defined.");
+    }
+}

--- a/src/features/forms/routes/instance/formItems/fileItem.tsx
+++ b/src/features/forms/routes/instance/formItems/fileItem.tsx
@@ -163,7 +163,12 @@ export default function FileItem({
                 <MoreVert />
             </IconButton>
             <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClick={stopPropagation} onClose={closeMenu}>
-                <MenuItem onClick={() => downloadFile(file)}>
+                <MenuItem
+                    onClick={() => {
+                        downloadFile(file);
+                        closeMenu();
+                    }}
+                >
                     <Download fontSize="small" />
                     <ListItemText primary="Download" />
                 </MenuItem>

--- a/src/features/forms/routes/instance/formItems/fileItem.tsx
+++ b/src/features/forms/routes/instance/formItems/fileItem.tsx
@@ -1,4 +1,11 @@
-import { Delete, Download, FilePresentOutlined, MoreVert, PictureAsPdfOutlined } from "@mui/icons-material";
+import {
+    AttachFileOutlined,
+    Delete,
+    Download,
+    FilePresentOutlined,
+    MoreVert,
+    PictureAsPdfOutlined,
+} from "@mui/icons-material";
 import {
     Box,
     css,
@@ -24,8 +31,7 @@ export interface FileItemProps {
     isReadonly: boolean;
     activeImage: string;
     isModalOpen: boolean;
-    index: number;
-    removeFile: (index: number) => void;
+    removeFile: () => void;
     openImageModal: (url?: string) => void;
 }
 
@@ -44,7 +50,6 @@ export default function FileItem({
     isReadonly,
     activeImage,
     isModalOpen,
-    index,
     removeFile,
     openImageModal,
 }: FileItemProps) {
@@ -68,7 +73,11 @@ export default function FileItem({
     const isImage = /^image\//.test(file.type);
     const isPdf = /^application\/pdf$/.test(file.type);
     const icon = isImage ? (
-        <Img src={file.url} alt={file.name} crossOrigin="anonymous" />
+        file.url ? (
+            <Img src={file.url} alt={file.name} crossOrigin="anonymous" />
+        ) : (
+            <AttachFileOutlined sx={{ width: 50, height: 50 }} />
+        )
     ) : isPdf ? (
         <PictureAsPdfOutlined sx={{ width: 50, height: 50 }} />
     ) : (
@@ -76,17 +85,15 @@ export default function FileItem({
     );
 
     const handleFileClick = () => {
-        if (isImage) {
+        if (!file.url) {
+            return;
+        } else if (isImage) {
             openImageModal(file.url);
         } else if (isPdf) {
             window.open(file.url, "_blank");
         } else {
             downloadFile(file);
         }
-    };
-
-    const handleRemoveFile = () => {
-        removeFile(index);
     };
 
     return (
@@ -133,7 +140,7 @@ export default function FileItem({
                     sx={{ ml: 1 }}
                     primary={
                         <Tooltip disableInteractive title={file.name}>
-                            <Box>{file.name}</Box>
+                            <span>{file.name}</span>
                         </Tooltip>
                     }
                     primaryTypographyProps={{
@@ -161,7 +168,7 @@ export default function FileItem({
                     <ListItemText primary="Download" />
                 </MenuItem>
                 {!isReadonly && (
-                    <MenuItem onClick={handleRemoveFile}>
+                    <MenuItem onClick={removeFile}>
                         <Delete fontSize="small" />
                         <ListItemText primary="Remove" />
                     </MenuItem>

--- a/src/features/forms/routes/instance/locationInstance.tsx
+++ b/src/features/forms/routes/instance/locationInstance.tsx
@@ -170,6 +170,8 @@ export function LocationInstance() {
     }, [currentFormsList, history, dispatch]);
 
     const handleClearClick = useCallback(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         setItems((state) =>
             state.map((item) => ({
                 ...item,

--- a/src/features/forms/routes/instance/locationInstance.tsx
+++ b/src/features/forms/routes/instance/locationInstance.tsx
@@ -19,7 +19,8 @@ import {
     type FormId,
     type FormItem as FItype,
     FormItemType,
-    FormRecord,
+    type FormRecord,
+    type FormsFile,
     type TemplateId,
 } from "features/forms/types";
 import { toFormFields, toFormItems } from "features/forms/utils";
@@ -170,13 +171,18 @@ export function LocationInstance() {
     }, [currentFormsList, history, dispatch]);
 
     const handleClearClick = useCallback(() => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         setItems((state) =>
-            state.map((item) => ({
-                ...item,
-                value: item.type !== FormItemType.Text ? null : item.value,
-            }))
+            state.map((item) =>
+                item.type === FormItemType.File
+                    ? {
+                          ...item,
+                          value: item.value as FormsFile[],
+                      }
+                    : {
+                          ...item,
+                          value: item.type !== FormItemType.Text ? null : item.value,
+                      }
+            )
         );
         setIsUpdated(true);
     }, []);

--- a/src/features/forms/routes/instance/searchInstance.tsx
+++ b/src/features/forms/routes/instance/searchInstance.tsx
@@ -13,7 +13,14 @@ import { renderActions } from "features/render";
 import { useSceneId } from "hooks/useSceneId";
 
 import { useGetSearchFormQuery, useUpdateSearchFormMutation } from "../../api";
-import { type Form, type FormId, type FormItem as FItype, FormItemType, type FormObjectGuid } from "../../types";
+import {
+    type Form,
+    type FormId,
+    type FormItem as FItype,
+    FormItemType,
+    type FormObjectGuid,
+    type FormsFile,
+} from "../../types";
 import { determineHighlightCollection, toFormFields, toFormItems } from "../../utils";
 import { FormItem } from "./formItem";
 
@@ -131,13 +138,18 @@ export function SearchInstance() {
     }, [dispatchHighlighted, dispatch, currentFormsList, history]);
 
     const handleClearClick = useCallback(() => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         setItems((state) =>
-            state.map((item) => ({
-                ...item,
-                value: item.type !== FormItemType.Text ? null : item.value,
-            }))
+            state.map((item) =>
+                item.type === FormItemType.File
+                    ? {
+                          ...item,
+                          value: item.value as FormsFile[],
+                      }
+                    : {
+                          ...item,
+                          value: item.type !== FormItemType.Text ? null : item.value,
+                      }
+            )
         );
         setIsUpdated(true);
     }, []);

--- a/src/features/forms/routes/instance/searchInstance.tsx
+++ b/src/features/forms/routes/instance/searchInstance.tsx
@@ -131,6 +131,8 @@ export function SearchInstance() {
     }, [dispatchHighlighted, dispatch, currentFormsList, history]);
 
     const handleClearClick = useCallback(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         setItems((state) =>
             state.map((item) => ({
                 ...item,

--- a/src/features/forms/types.ts
+++ b/src/features/forms/types.ts
@@ -12,7 +12,11 @@ export enum FormItemType {
 
 export type FormItem = SimpleItem | ItemWithOptions | FileItem;
 
-type BaseItem<T extends string[] | (File & { checksum?: string; url?: string })[] | null = string[] | null> = {
+export type FormFileUploadResponce = { checksum?: string; url?: string };
+
+export type FormsFile = File & FormFileUploadResponce;
+
+type BaseItem<T extends string[] | FormsFile[] | null> = {
     id?: string;
     title: string;
     required: boolean;
@@ -29,9 +33,14 @@ interface ItemWithOptions extends BaseItem<string[] | null> {
     options: string[];
 }
 
-interface FileItem extends BaseItem<(File & { checksum?: string; url?: string })[]> {
+interface ItemWithOptions extends BaseItem<string[] | null> {
+    type: Exclude<FormItemType, FormItemType.Input | FormItemType.Text | FormItemType.File>;
+    options: string[];
+}
+
+export interface FileItem extends BaseItem<FormsFile[]> {
     type: FormItemType.File;
-    defaultValue?: (File & { checksum?: string; url?: string })[];
+    defaultValue?: FormsFile[];
     accept: string;
     multiple: boolean;
     readonly: boolean;
@@ -110,8 +119,8 @@ export type FormField =
     | {
           type: "file";
           id?: string;
-          value?: (File & { checksum?: string; url?: string })[];
-          defaultValue?: (File & { checksum?: string; url?: string })[];
+          value?: FormsFile[];
+          defaultValue?: FormsFile[];
           label?: string;
           required?: boolean;
           readonly?: boolean;

--- a/src/features/forms/types.ts
+++ b/src/features/forms/types.ts
@@ -7,26 +7,36 @@ export enum FormItemType {
     Dropdown = "dropdown",
     Input = "input",
     Text = "text",
+    File = "file",
 }
 
-export type FormItem = SimpleItem | ItemWithOptions;
+export type FormItem = SimpleItem | ItemWithOptions | FileItem;
 
-type BaseItem = {
+type BaseItem<T extends string[] | (File & { checksum?: string; url?: string })[] | null = string[] | null> = {
     id?: string;
     title: string;
     required: boolean;
-    value?: string[] | null;
+    value?: T;
     relevant?: boolean;
 };
 
-type SimpleItem = BaseItem & {
-    type: Exclude<FormItemType, FormItemType.Dropdown | FormItemType.Checkbox>;
+type SimpleItem = BaseItem<string[] | null> & {
+    type: Exclude<FormItemType, FormItemType.Dropdown | FormItemType.Checkbox | FormItemType.File>;
 };
 
-type ItemWithOptions = BaseItem & {
-    type: Exclude<FormItemType, SimpleItem["type"]>;
+interface ItemWithOptions extends BaseItem<string[] | null> {
+    type: Exclude<FormItemType, FormItemType.Input | FormItemType.Text | FormItemType.File>;
     options: string[];
-};
+}
+
+interface FileItem extends BaseItem<(File & { checksum?: string; url?: string })[]> {
+    type: FormItemType.File;
+    defaultValue?: (File & { checksum?: string; url?: string })[];
+    accept: string;
+    multiple: boolean;
+    readonly: boolean;
+    dirrectory?: boolean;
+}
 
 export type ProjectId = string;
 export type TemplateId = string;
@@ -97,7 +107,18 @@ export type FormField =
           multiple?: boolean;
           options: { label: string; value: string; checked?: boolean }[];
       }
-    | { type: "file"; id?: string; required?: boolean; readonly?: boolean; accept?: string[] };
+    | {
+          type: "file";
+          id?: string;
+          value?: (File & { checksum?: string; url?: string })[];
+          defaultValue?: (File & { checksum?: string; url?: string })[];
+          label?: string;
+          required?: boolean;
+          readonly?: boolean;
+          accept?: string;
+          multiple?: boolean;
+          dirrectory?: boolean;
+      };
 
 export type FormObjectGuid = string;
 
@@ -194,3 +215,5 @@ export type FormTransform = {
     scale?: number;
     updated: boolean;
 };
+
+export type FileTypes = ("Documents" | "Images")[];

--- a/src/features/forms/types.ts
+++ b/src/features/forms/types.ts
@@ -12,9 +12,9 @@ export enum FormItemType {
 
 export type FormItem = SimpleItem | ItemWithOptions | FileItem;
 
-export type FormFileUploadResponce = { checksum?: string; url?: string };
+export type FormFileUploadResponse = { checksum?: string; url?: string };
 
-export type FormsFile = File & FormFileUploadResponce;
+export type FormsFile = File & FormFileUploadResponse;
 
 type BaseItem<T extends string[] | FormsFile[] | null> = {
     id?: string;
@@ -44,7 +44,7 @@ export interface FileItem extends BaseItem<FormsFile[]> {
     accept: string;
     multiple: boolean;
     readonly: boolean;
-    dirrectory?: boolean;
+    directory?: boolean;
 }
 
 export type ProjectId = string;
@@ -126,7 +126,7 @@ export type FormField =
           readonly?: boolean;
           accept?: string;
           multiple?: boolean;
-          dirrectory?: boolean;
+          directory?: boolean;
       };
 
 export type FormObjectGuid = string;

--- a/src/features/forms/utils.ts
+++ b/src/features/forms/utils.ts
@@ -284,6 +284,24 @@ function toFormField(item: FormItem): FormField {
             ...(item.id ? { id: item.id } : {}),
         };
     }
+    if (item.type === FormItemType.File) {
+        // NOTE: Mapping the value is required to serialize it later
+        return {
+            type: "file",
+            label: item.title,
+            accept: item.accept,
+            multiple: item.multiple,
+            readonly: item.readonly,
+            value: item.value?.map((f) => ({
+                lastModified: f.lastModified,
+                name: f.name,
+                size: f.size,
+                type: f.type,
+                checksum: f.checksum,
+            })) as (File & { checksum?: string; url?: string })[],
+            ...(item.id ? { id: item.id } : {}),
+        };
+    }
     throw new Error(`Unknown form item type: ${item.type}`);
 }
 
@@ -338,6 +356,20 @@ function toFormItem(field: FormField): FormItem {
             ...(field.id ? { id: field.id } : {}),
         };
     }
+    if (field.type === "file") {
+        return {
+            type: FormItemType.File,
+            title: field.label ?? "",
+            value: field.value,
+            defaultValue: field.defaultValue,
+            required: field.required ?? false,
+            readonly: field.readonly ?? false,
+            accept: field.accept ?? "",
+            multiple: field.multiple ?? false,
+            dirrectory: field.dirrectory ?? false,
+            ...(field.id ? { id: field.id } : {}),
+        };
+    }
     throw new Error(`Unknown form field type: ${field.type}`);
 }
 
@@ -356,6 +388,8 @@ export function getFormItemTypeDisplayName(type: FormItemType): string {
         case FormItemType.Input:
         case FormItemType.Text:
             return type[0].toUpperCase() + type.slice(1);
+        case FormItemType.File:
+            return "File";
     }
 }
 

--- a/src/features/forms/utils.ts
+++ b/src/features/forms/utils.ts
@@ -12,6 +12,7 @@ import {
     FormItemType,
     type FormObject,
     type FormObjectGuid,
+    type FormsFile,
     type FormState,
 } from "./types";
 
@@ -291,6 +292,7 @@ function toFormField(item: FormItem): FormField {
             label: item.title,
             accept: item.accept,
             multiple: item.multiple,
+            required: item.required,
             readonly: item.readonly,
             value: item.value?.map((f) => ({
                 lastModified: f.lastModified,
@@ -298,7 +300,7 @@ function toFormField(item: FormItem): FormField {
                 size: f.size,
                 type: f.type,
                 checksum: f.checksum,
-            })) as (File & { checksum?: string; url?: string })[],
+            })) as FormsFile[],
             ...(item.id ? { id: item.id } : {}),
         };
     }
@@ -424,8 +426,8 @@ function isFormFieldFilled(field: FormField): boolean {
         case "checkbox":
             return typeof field.value === "boolean";
         case "select":
+        case "file":
             return (field.value?.length ?? 0) > 0;
-        // TODO(ND) file
         default:
             return false;
     }

--- a/src/features/forms/utils.ts
+++ b/src/features/forms/utils.ts
@@ -300,6 +300,7 @@ function toFormField(item: FormItem): FormField {
                 size: f.size,
                 type: f.type,
                 checksum: f.checksum,
+                url: f.url,
             })) as FormsFile[],
             ...(item.id ? { id: item.id } : {}),
         };
@@ -368,7 +369,7 @@ function toFormItem(field: FormField): FormItem {
             readonly: field.readonly ?? false,
             accept: field.accept ?? "",
             multiple: field.multiple ?? false,
-            dirrectory: field.dirrectory ?? false,
+            directory: field.directory ?? false,
             ...(field.id ? { id: field.id } : {}),
         };
     }


### PR DESCRIPTION
* Add support for uploading files to forms
User can add file item to the form. Files can be uploaded either at form creation stage or when form instance is filled by the user.
* Forms display rich element with previews for images & PDFs.
* Form creation dialog is updated to reflect growing number of items' types that are supported.