### PR TITLE
Feature/show form markers when forms are closed

### DIFF
--- a/src/dataApi.d.ts
+++ b/src/dataApi.d.ts
@@ -183,6 +183,9 @@ declare module "@novorender/data-js-api" {
                 }[];
             }[];
         };
+        forms?: {
+            alwaysShowMarkers: boolean;
+        };
     };
 
     interface Bookmark {

--- a/src/features/bookmarks/useCreateBookmark.ts
+++ b/src/features/bookmarks/useCreateBookmark.ts
@@ -17,6 +17,7 @@ import {
     selectSelectedSubprofileIndex,
 } from "features/deviations/selectors";
 import { selectFollowPath } from "features/followPath/followPathSlice";
+import { selectAlwaysShowMarkers } from "features/forms/slice";
 import {
     selectManholeCollisionSettings,
     selectManholeCollisionTarget,
@@ -72,6 +73,7 @@ export function useCreateBookmark() {
     const deviationLegendFloating = useAppSelector(selectIsLegendFloating);
     const deviationLegendGroups = useAppSelector(selectDeviationLegendGroups);
     const arcgisFeatureServers = useAppSelector(selectArcgisFeatureServers);
+    const alwaysShowMarkerForms = useAppSelector(selectAlwaysShowMarkers);
 
     const {
         state: { view },
@@ -264,6 +266,9 @@ export function useCreateBookmark() {
                               })),
                           }
                         : undefined,
+                forms: {
+                    alwaysShowMarkers: alwaysShowMarkerForms,
+                },
             },
         };
     };

--- a/src/features/forms/api.ts
+++ b/src/features/forms/api.ts
@@ -223,6 +223,7 @@ export const formsApi = createApi({
 
 export const {
     useListTemplatesQuery,
+    useLazyListTemplatesQuery,
     useGetSearchFormQuery,
     useGetLocationFormQuery,
     useGetSearchFormsQuery,

--- a/src/features/forms/forms.tsx
+++ b/src/features/forms/forms.tsx
@@ -1,4 +1,5 @@
-import { Box } from "@mui/material";
+import { Settings as SettingsIcon } from "@mui/icons-material";
+import { Box, ListItemIcon, ListItemText, Menu, MenuItem, MenuProps } from "@mui/material";
 import { PropsWithChildren, useEffect, useRef } from "react";
 import { MemoryRouter, Route, Switch, SwitchProps, useHistory } from "react-router-dom";
 
@@ -15,8 +16,8 @@ import { selectMaximized, selectMinimized } from "slices/explorer";
 
 import { useGoToSelectedForm } from "./hooks/useGoToSelectedForm";
 import { useLoadLocationTemplates } from "./hooks/useLoadLocationTemplates";
-import { useRenderLocationFormAssets } from "./hooks/useRenderLocationFormAssets";
 import { Create, FormsList, LocationInstance, Object, SearchInstance, Templates } from "./routes";
+import { Settings } from "./routes/settings";
 import { formsActions } from "./slice";
 
 export default function Forms() {
@@ -25,45 +26,45 @@ export default function Forms() {
     const maximized = useAppSelector(selectMaximized).includes(featuresConfig.forms.key);
 
     useLoadLocationTemplates();
-    useRenderLocationFormAssets();
 
     return (
-        <>
+        <MemoryRouter>
             <WidgetContainer minimized={minimized} maximized={maximized}>
-                <WidgetHeader widget={featuresConfig.forms} disableShadow={!menuOpen} />
+                <WidgetHeader WidgetMenu={WidgetMenu} widget={featuresConfig.forms} disableShadow={!menuOpen} />
                 <Box
                     display={menuOpen || minimized ? "none" : "flex"}
                     flexDirection="column"
                     flexGrow={1}
                     overflow="hidden"
                 >
-                    <MemoryRouter>
-                        <CustomSwitch>
-                            <Route path="/" exact>
-                                <Templates />
-                            </Route>
-                            <Route path="/forms/:templateId">
-                                <FormsList />
-                            </Route>
-                            <Route path="/search-instance/:objectGuid-:formId">
-                                <SearchInstance />
-                            </Route>
-                            <Route path="/location-instance/:templateId-:formId">
-                                <LocationInstance />
-                            </Route>
-                            <Route path="/object/:id">
-                                <Object />
-                            </Route>
-                            <Route path="/create">
-                                <Create />
-                            </Route>
-                        </CustomSwitch>
-                    </MemoryRouter>
+                    <CustomSwitch>
+                        <Route path="/" exact>
+                            <Templates />
+                        </Route>
+                        <Route path="/forms/:templateId">
+                            <FormsList />
+                        </Route>
+                        <Route path="/search-instance/:objectGuid-:formId">
+                            <SearchInstance />
+                        </Route>
+                        <Route path="/location-instance/:templateId-:formId">
+                            <LocationInstance />
+                        </Route>
+                        <Route path="/object/:id">
+                            <Object />
+                        </Route>
+                        <Route path="/create">
+                            <Create />
+                        </Route>
+                        <Route path="/settings">
+                            <Settings />
+                        </Route>
+                    </CustomSwitch>
                 </Box>
                 {menuOpen && <WidgetList widgetKey={featuresConfig.forms.key} onSelect={toggleMenu} />}
             </WidgetContainer>
             <LogoSpeedDial open={menuOpen} toggle={toggleMenu} />
-        </>
+        </MemoryRouter>
     );
 }
 
@@ -106,4 +107,24 @@ function CustomSwitch(props: PropsWithChildren<SwitchProps>) {
     useGoToSelectedForm();
 
     return <Switch {...props} />;
+}
+
+function WidgetMenu(props: MenuProps) {
+    const history = useHistory();
+
+    return (
+        <Menu {...props}>
+            <MenuItem
+                onClick={() => {
+                    history.push("/settings");
+                    props.onClose?.({}, "backdropClick");
+                }}
+            >
+                <ListItemIcon>
+                    <SettingsIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>Settings</ListItemText>
+            </MenuItem>
+        </Menu>
+    );
 }

--- a/src/features/forms/formsTopDown.tsx
+++ b/src/features/forms/formsTopDown.tsx
@@ -7,7 +7,7 @@ import { featuresConfig } from "config/features";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { areArraysEqual } from "features/arcgis/utils";
 import { CameraType, selectCameraType } from "features/render";
-import { selectWidgets } from "slices/explorer";
+import { explorerActions, selectWidgets } from "slices/explorer";
 import { AsyncStatus } from "types/misc";
 
 import { useFetchAssetList } from "./hooks/useFetchAssetList";
@@ -141,6 +141,7 @@ export const FormsTopDown = forwardRef(function FormsTopDown(_props, ref) {
         } else {
             dispatch(formsActions.setCurrentFormsList(templateId));
             dispatch(formsActions.setSelectedFormId(id));
+            dispatch(explorerActions.forceOpenWidget(featuresConfig.forms.key));
         }
     };
 

--- a/src/features/forms/formsTopDown.tsx
+++ b/src/features/forms/formsTopDown.tsx
@@ -3,6 +3,7 @@ import { ReadonlyVec2, ReadonlyVec3 } from "gl-matrix";
 import { forwardRef, MouseEvent, useImperativeHandle, useMemo, useRef } from "react";
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { featuresConfig } from "config/features";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { areArraysEqual } from "features/arcgis/utils";
 import { CameraType, selectCameraType } from "features/render";
@@ -13,6 +14,7 @@ import { useFetchAssetList } from "./hooks/useFetchAssetList";
 import { AssetIcon } from "./routes/create/assetIcon";
 import {
     formsActions,
+    selectAlwaysShowMarkers,
     selectCurrentFormsList,
     selectLocationForms,
     selectSelectedFormId,
@@ -46,11 +48,14 @@ export const FormsTopDown = forwardRef(function FormsTopDown(_props, ref) {
     const templates = useAppSelector(selectTemplates);
     const selectedFormId = useAppSelector(selectSelectedFormId);
     const selectedTemplateId = useAppSelector(selectCurrentFormsList);
-    const isFormsWidgetAdded = useAppSelector((state) => selectWidgets(state).includes("forms"));
-    const active = useAppSelector(selectCameraType) === CameraType.Orthographic && isFormsWidgetAdded;
+    const isFormsWidgetOpen = useAppSelector((state) => selectWidgets(state).includes(featuresConfig.forms.key));
+    const alwaysShowMarkers = useAppSelector(selectAlwaysShowMarkers);
+    const active =
+        useAppSelector(selectCameraType) === CameraType.Orthographic && (isFormsWidgetOpen || alwaysShowMarkers);
     const dispatch = useAppDispatch();
     const containerRef = useRef<HTMLDivElement | null>(null);
-    const assetList = useFetchAssetList();
+
+    const assetList = useFetchAssetList({ skip: !active });
 
     const iconMap = useMemo(() => {
         if (assetList.status !== AsyncStatus.Success) {

--- a/src/features/forms/hooks/useFetchAssetList.ts
+++ b/src/features/forms/hooks/useFetchAssetList.ts
@@ -7,7 +7,7 @@ import { AsyncStatus } from "types/misc";
 import { formsActions, selectAssets } from "../slice";
 import { FormGLtfAsset } from "../types";
 
-export function useFetchAssetList() {
+export function useFetchAssetList({ skip = false }: { skip?: boolean } = {}) {
     const assets = useAppSelector(selectAssets);
     const dispatch = useAppDispatch();
     const assetsUrl = useAppSelector(selectConfig).assetsUrl;
@@ -16,7 +16,7 @@ export function useFetchAssetList() {
         getAssets();
 
         async function getAssets() {
-            if (assets.status !== AsyncStatus.Initial) {
+            if (assets.status !== AsyncStatus.Initial || skip) {
                 return;
             }
 
@@ -29,7 +29,7 @@ export function useFetchAssetList() {
             }));
             dispatch(formsActions.setAssets({ status: AsyncStatus.Success, data }));
         }
-    }, [dispatch, assets, assetsUrl]);
+    }, [dispatch, assets, assetsUrl, skip]);
 
     return assets;
 }

--- a/src/features/forms/hooks/useFetchLocationForms.ts
+++ b/src/features/forms/hooks/useFetchLocationForms.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+
+import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { featuresConfig } from "config/features";
+import { useSceneId } from "hooks/useSceneId";
+import { selectWidgets } from "slices/explorer";
+import { AsyncStatus } from "types/misc";
+
+import { useLazyGetTemplateQuery, useLazyListTemplatesQuery } from "../api";
+import { formsActions, selectAlwaysShowMarkers } from "../slice";
+import { TemplateType } from "../types";
+
+/**
+ * Used for initial location form loading.
+ * Template and form loading is controlled by Forms widget.
+ * When have alwaysShowMarkers=true - we need to load location forms before Forms widget is visible.
+ * This hook will only load forms one time, after that Forms widget catches up.
+ */
+export function useFetchInitialLocationForms() {
+    const projectId = useSceneId();
+    const isFormWidgetOpen = useAppSelector((state) => selectWidgets(state).includes(featuresConfig.forms.key));
+    const alwaysShowMarkers = useAppSelector(selectAlwaysShowMarkers);
+    const dispatch = useAppDispatch();
+
+    const status = useRef(AsyncStatus.Initial);
+
+    const [listTemplates] = useLazyListTemplatesQuery();
+    const [getTemplate] = useLazyGetTemplateQuery();
+
+    useEffect(() => {
+        if (isFormWidgetOpen) {
+            // In this case Forms widget is responsible for loading
+            status.current = AsyncStatus.Success;
+        }
+    }, [isFormWidgetOpen]);
+
+    useEffect(() => {
+        load();
+
+        async function load() {
+            if (status.current !== AsyncStatus.Initial || !alwaysShowMarkers || !projectId) {
+                return;
+            }
+
+            status.current = AsyncStatus.Loading;
+
+            try {
+                const templateIds = await listTemplates({ projectId }, true).unwrap();
+                const templates = await Promise.all(
+                    templateIds.map((templateId) => getTemplate({ projectId, templateId }, true).unwrap())
+                );
+                dispatch(formsActions.setTemplates({ status: AsyncStatus.Success, data: templates }));
+                const locationForms = templates
+                    .filter((t) => t.type === TemplateType.Location && t.forms)
+                    .flatMap((t) => Object.entries(t.forms!).map(([id, form]) => ({ ...form, id, templateId: t.id! })));
+
+                dispatch(formsActions.addLocationForms(locationForms));
+                status.current = AsyncStatus.Success;
+            } catch (error) {
+                console.error(error);
+                status.current = AsyncStatus.Error;
+            }
+        }
+    }, [dispatch, projectId, alwaysShowMarkers, listTemplates, getTemplate]);
+}

--- a/src/features/forms/hooks/useLocationFormAssetClickHandler.ts
+++ b/src/features/forms/hooks/useLocationFormAssetClickHandler.ts
@@ -2,6 +2,8 @@ import { PickSampleExt } from "@novorender/api";
 import { useCallback } from "react";
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { featuresConfig } from "config/features";
+import { explorerActions } from "slices/explorer";
 
 import { useLazyFormsGlobals } from "../formsGlobals/hooks";
 import { formsActions, selectCurrentFormsList, selectSelectedFormId } from "../slice";
@@ -25,8 +27,11 @@ export function useLocationFormAssetClickHandler() {
 
             if (!isSelected) {
                 dispatch(formsActions.setCurrentFormsList(templateId));
+                dispatch(formsActions.setSelectedFormId(formId));
+                dispatch(explorerActions.forceOpenWidget(featuresConfig.forms.key));
+            } else {
+                dispatch(formsActions.setSelectedFormId(undefined));
             }
-            dispatch(formsActions.setSelectedFormId(isSelected ? undefined : formId));
 
             return true;
         },

--- a/src/features/forms/hooks/usePlaceLocationForm.ts
+++ b/src/features/forms/hooks/usePlaceLocationForm.ts
@@ -9,11 +9,8 @@ import { useCreateLocationFormMutation } from "../api";
 import { formsGlobalsActions } from "../formsGlobals";
 import { useDispatchFormsGlobals } from "../formsGlobals/hooks";
 import { formsActions, selectCurrentFormsList, selectSelectedFormId } from "../slice";
-import { useFetchAssetList } from "./useFetchAssetList";
 
 export function usePlaceLocationForm() {
-    useFetchAssetList();
-
     const templateId = useAppSelector(selectCurrentFormsList);
     const selectedFormId = useAppSelector(selectSelectedFormId);
     const dispatchFormsGlobals = useDispatchFormsGlobals();

--- a/src/features/forms/hooks/useRenderLocationFormAssets.ts
+++ b/src/features/forms/hooks/useRenderLocationFormAssets.ts
@@ -117,6 +117,17 @@ export function useRenderLocationFormAssets() {
         }
     }, [templates, locationForms, active, transform]);
 
+    const baseObjectIdSet = useMemo(() => {
+        const baseObjectIdSet = new Set<number>();
+        if (assetInfoList.status === AsyncStatus.Success) {
+            for (const { baseObjectId } of assetInfoList.data) {
+                baseObjectIdSet.add(baseObjectId);
+                baseObjectIdSet.add(baseObjectId + SELECTED_OBJECT_ID_OFFSET);
+            }
+        }
+        return baseObjectIdSet;
+    }, [assetInfoList]);
+
     const uniqueMarkers = useMemo(() => {
         const uniqueMarkers = new Set<string>();
         for (const form of renderedForms) {
@@ -181,13 +192,8 @@ export function useRenderLocationFormAssets() {
                 return;
             }
 
-            const baseObjectIdSet = new Set<number>(assetInfoList.data.map((a) => a.baseObjectId));
-
             const objects = view.renderState.dynamic.objects.filter(
-                (obj) =>
-                    !obj.baseObjectId ||
-                    (!baseObjectIdSet.has(obj.baseObjectId) &&
-                        !baseObjectIdSet.has(obj.baseObjectId + SELECTED_OBJECT_ID_OFFSET))
+                (obj) => !obj.baseObjectId || !baseObjectIdSet.has(obj.baseObjectId)
             );
 
             needCleaning.current = false;
@@ -269,13 +275,8 @@ export function useRenderLocationFormAssets() {
 
             let objects = view.renderState.dynamic.objects as RenderStateDynamicObject[];
             if (needCleaning.current) {
-                const baseObjectIdSet = new Set<number>(assetInfoList.data.map((a) => a.baseObjectId));
-
                 objects = view.renderState.dynamic.objects.filter(
-                    (obj) =>
-                        !obj.baseObjectId ||
-                        (!baseObjectIdSet.has(obj.baseObjectId) &&
-                            !baseObjectIdSet.has(obj.baseObjectId + SELECTED_OBJECT_ID_OFFSET))
+                    (obj) => !obj.baseObjectId || !baseObjectIdSet.has(obj.baseObjectId)
                 );
 
                 needCleaning.current = false;
@@ -321,6 +322,7 @@ export function useRenderLocationFormAssets() {
         active,
         assetGltfMap,
         dispatchFormsGlobals,
+        baseObjectIdSet,
     ]);
 }
 

--- a/src/features/forms/routes/settings/index.tsx
+++ b/src/features/forms/routes/settings/index.tsx
@@ -1,0 +1,1 @@
+export { Settings } from "./settings";

--- a/src/features/forms/routes/settings/settings.tsx
+++ b/src/features/forms/routes/settings/settings.tsx
@@ -1,0 +1,44 @@
+import { ArrowBack } from "@mui/icons-material";
+import { Box, Button, Divider, FormControlLabel, useTheme } from "@mui/material";
+import { useHistory } from "react-router-dom";
+
+import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { IosSwitch, ScrollBox } from "components";
+import { formsActions, selectAlwaysShowMarkers } from "features/forms/slice";
+
+export function Settings() {
+    const theme = useTheme();
+    const history = useHistory();
+    const alwaysShowMarkers = useAppSelector(selectAlwaysShowMarkers);
+    const dispatch = useAppDispatch();
+
+    return (
+        <>
+            <Box boxShadow={theme.customShadows.widgetHeader}>
+                <Box px={1}>
+                    <Divider />
+                </Box>
+                <Box display="flex" justifyContent="space-between">
+                    <Button onClick={() => history.goBack()} color="grey">
+                        <ArrowBack sx={{ mr: 1 }} />
+                        Back
+                    </Button>
+                </Box>
+            </Box>
+            <ScrollBox pt={2} pb={3}>
+                <FormControlLabel
+                    control={
+                        <IosSwitch
+                            size="medium"
+                            color="primary"
+                            checked={alwaysShowMarkers}
+                            onChange={() => dispatch(formsActions.toggleAlwaysShowMarkers())}
+                        />
+                    }
+                    label={<Box fontSize={14}>Show markers when component is closed</Box>}
+                    sx={{ ml: 1 }}
+                />
+            </ScrollBox>
+        </>
+    );
+}

--- a/src/features/forms/slice.tsx
+++ b/src/features/forms/slice.tsx
@@ -129,9 +129,6 @@ export const formsSlice = createSlice({
         toggleAlwaysShowMarkers: (state, _action: PayloadAction<void>) => {
             state.alwaysShowMarkers = !state.alwaysShowMarkers;
         },
-        setAlwaysShowMarkers: (state, action: PayloadAction<State["alwaysShowMarkers"]>) => {
-            state.alwaysShowMarkers = action.payload;
-        },
         removeLocationFormsNotInTemplates: (state, action: PayloadAction<TemplateId[]>) => {
             const newForms = state.locationForms.filter((f) => action.payload.includes(f.templateId));
             if (state.locationForms.length !== newForms.length) {

--- a/src/features/render/render.tsx
+++ b/src/features/render/render.tsx
@@ -11,6 +11,7 @@ import { useHandleDitioAuth } from "features/ditio";
 import { Engine2D } from "features/engine2D/engine2D";
 import { Engine2DHtmlInteractions } from "features/engine2D/engine2DHtmlInteractions";
 import { Engine2DInteractions } from "features/engine2D/engine2DInteractions";
+import { useRenderLocationFormAssets } from "features/forms/hooks/useRenderLocationFormAssets";
 import { useHandleImages } from "features/images";
 import { useHandleJiraKeepAlive } from "features/jira";
 import { useHandleManhole } from "features/manhole";
@@ -131,6 +132,8 @@ export function Render3D() {
     useHandleXsiteManageKeepAlive();
     useHandleXsiteManageMachineLocations();
     useHandleDitioAuth();
+
+    useRenderLocationFormAssets();
 
     const cursor = useHandleCanvasCursor();
     const onClick = useCanvasClickHandler({ pointerDownStateRef });


### PR DESCRIPTION
https://trello.com/c/jYv9AlDq/822-forms-issues-with-sign-rect-marker
https://trello.com/c/suGOtFwd/829-forms-showing-the-markers-without-opening-forms-widget

Also fixes issue with "Sign rect" marker and don't load assets.json until needed.
My testing project is 2a1ab3f9ff744150ad712a9d9e08a849
Share link with enabled option in 3d - 2a1ab3f9ff744150ad712a9d9e08a849?bookmarkId=1fad8bbf-04ba-47e9-882f-8d74af556c83
In ortho - 2a1ab3f9ff744150ad712a9d9e08a849?bookmarkId=ad19818d-8c95-4b70-9aa2-5cd1788c19fc