### PR TITLE
When initializing camera from `view.renderState.camera` - pass only expected attributes

### DIFF
--- a/src/features/render/hooks/useHandleInit.ts
+++ b/src/features/render/hooks/useHandleInit.ts
@@ -96,7 +96,13 @@ export function useHandleInit() {
                         tmZoneForCalc,
                         sceneData,
                         sceneConfig: octreeSceneConfig,
-                        initialCamera: sceneCamera ?? getDefaultCamera(projectV2?.bounds) ?? view.renderState.camera,
+                        initialCamera: sceneCamera ??
+                            getDefaultCamera(projectV2?.bounds) ?? {
+                                position: view.renderState.camera.position,
+                                rotation: view.renderState.camera.rotation,
+                                fov: view.renderState.camera.fov,
+                                kind: view.renderState.camera.kind,
+                            },
                         deviceProfile,
                     })
                 );


### PR DESCRIPTION
If we pass near/far plane - it will mess things up when changing near/far plane in adv. settings (values will keep reset to whatever was passed in `initialCamera`)

https://trello.com/c/PQVTJyhl/852-camera-near-far-plane-resets-after-changing-it