### PR TITLE
When searching for Novorender/PathId - don't limit `descentDepth`, be…

### DIFF
--- a/src/features/render/canvasContextMenuStamp/stamp.tsx
+++ b/src/features/render/canvasContextMenuStamp/stamp.tsx
@@ -351,7 +351,6 @@ async function getRoadCenterLine({
         const iterator = db.search(
             {
                 parentPath,
-                descentDepth: 1,
                 searchPattern: [{ property: "Novorender/PathId", value: "" }],
             },
             signal,


### PR DESCRIPTION
…cause we don't know where exactly it's going to be

https://trello.com/c/t1tnv32J/855-center-line-search-for-novorender-pathid-all-over-ifc