### PR TITLE
Add hooks to open/replace/close widgets to have consistent mixpanel reporting

### DIFF
--- a/src/components/widgetHeader.tsx
+++ b/src/components/widgetHeader.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { Widget, WidgetKey } from "config/features";
+import { useRemoveWidget } from "hooks/useRemoveWidget";
 import {
     explorerActions,
     selectFavoriteWidgets,
@@ -14,7 +15,6 @@ import {
     selectNewDesign,
     selectPositionedWidgets,
 } from "slices/explorer";
-import { mixpanel } from "utils/mixpanel";
 
 import { Divider } from "./divider";
 
@@ -56,11 +56,12 @@ function WidgetHeaderNew({
     const minimized = useAppSelector(selectMinimized) === key;
     const isFavorite = useAppSelector((state) => selectFavoriteWidgets(state).includes(key));
     const dispatch = useAppDispatch();
+    const removeWidget = useRemoveWidget();
 
     const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
     const handleClose = () => {
-        dispatch(explorerActions.removeWidgetSlot(key));
+        removeWidget(key);
     };
 
     const openMenu = (e: MouseEvent<HTMLButtonElement>) => {
@@ -220,12 +221,12 @@ function WidgetHeaderOld({
     const maximized = useAppSelector(selectMaximized).includes(key);
     const minimized = useAppSelector(selectMinimized) === key;
     const dispatch = useAppDispatch();
+    const removeWidget = useRemoveWidget();
 
     const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
     const handleClose = () => {
-        mixpanel?.track("Closed Widget", { "Widget Key": key });
-        dispatch(explorerActions.removeWidgetSlot(key));
+        removeWidget(key);
     };
 
     const openMenu = (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/features/clippingPlanes/clippingPlaneInteractions.tsx
+++ b/src/features/clippingPlanes/clippingPlaneInteractions.tsx
@@ -30,7 +30,8 @@ import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { crossSectionActions } from "features/crossSection";
 import { getCameraDir } from "features/engine2D/utils";
 import { RenderState, selectClippingPlanes } from "features/render";
-import { explorerActions, selectNewDesign, selectWidgets } from "slices/explorer";
+import { useOpenWidget } from "hooks/useOpenWidget";
+import { selectNewDesign, selectWidgets } from "slices/explorer";
 import { rgbToHex, vecToRgb } from "utils/color";
 import { hasMouseSupport } from "utils/misc";
 
@@ -284,6 +285,7 @@ function PlaneMenu({
     const plane = clipping.planes[index];
     const isWidgetOpen = useAppSelector((state) => selectWidgets(state).includes(featuresConfig.clippingPlanes.key));
     const newDesign = useAppSelector(selectNewDesign);
+    const openWidget = useOpenWidget();
 
     const openMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.stopPropagation();
@@ -295,7 +297,7 @@ function PlaneMenu({
     };
 
     const showWidget = () => {
-        dispatch(explorerActions.forceOpenWidget(featuresConfig.clippingPlanes.key));
+        openWidget(featuresConfig.clippingPlanes.key, { force: true });
         closeMenu();
     };
 
@@ -325,7 +327,7 @@ function PlaneMenu({
     };
 
     const openCrossSection = () => {
-        dispatch(explorerActions.forceOpenWidget(featuresConfig.crossSection.key));
+        openWidget(featuresConfig.crossSection.key, { force: true });
         dispatch(crossSectionActions.setPlaneIndex(index));
         closeMenu();
     };

--- a/src/features/followPath/followInteractions.tsx
+++ b/src/features/followPath/followInteractions.tsx
@@ -4,7 +4,7 @@ import { SVGProps } from "react";
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { featuresConfig } from "config/features";
 import { renderActions } from "features/render";
-import { explorerActions } from "slices/explorer";
+import { useOpenWidget } from "hooks/useOpenWidget";
 import { ViewMode } from "types/misc";
 
 import {
@@ -47,7 +47,7 @@ const PlusMarker = styled(
             <path d="M95,100 L105,100 M100,95 L100,105" strokeWidth={2}></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(markerStyles);
 
 const MinusMarker = styled(
@@ -58,7 +58,7 @@ const MinusMarker = styled(
             <path d="M95,100 L105,100" strokeWidth={2}></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(markerStyles);
 
 const InfoMarker = styled(
@@ -72,7 +72,7 @@ const InfoMarker = styled(
             ></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(markerStyles);
 
 const basicStyle = () => css`
@@ -89,7 +89,7 @@ const CloseMarker = styled(
             <path d="M96,96 L104,104 M104,96 L96,104" stroke="white" strokeWidth={2}></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(basicStyle);
 
 export function FollowInteractions() {
@@ -99,6 +99,7 @@ export function FollowInteractions() {
     const step = useAppSelector(selectStep);
     const dispatch = useAppDispatch();
     const profileRange = useAppSelector(selectProfileRange);
+    const openWidget = useOpenWidget();
 
     const stepFollow = (dir: number) => {
         if (fpObj) {
@@ -142,7 +143,7 @@ export function FollowInteractions() {
                 onClick={() => {
                     dispatch(followPathActions.setLastViewedRouterPath("/followIds"));
                     dispatch(followPathActions.setGoToRouterPath("/followIds"));
-                    dispatch(explorerActions.forceOpenWidget(featuresConfig.followPath.key));
+                    openWidget(featuresConfig.followPath.key, { force: true });
                 }}
             />
             <CloseMarker

--- a/src/features/forms/formsTopDown.tsx
+++ b/src/features/forms/formsTopDown.tsx
@@ -7,7 +7,8 @@ import { featuresConfig } from "config/features";
 import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { areArraysEqual } from "features/arcgis/utils";
 import { CameraType, selectCameraType } from "features/render";
-import { explorerActions, selectWidgets } from "slices/explorer";
+import { useOpenWidget } from "hooks/useOpenWidget";
+import { selectWidgets } from "slices/explorer";
 import { AsyncStatus } from "types/misc";
 
 import { useFetchAssetList } from "./hooks/useFetchAssetList";
@@ -54,6 +55,7 @@ export const FormsTopDown = forwardRef(function FormsTopDown(_props, ref) {
         useAppSelector(selectCameraType) === CameraType.Orthographic && (isFormsWidgetOpen || alwaysShowMarkers);
     const dispatch = useAppDispatch();
     const containerRef = useRef<HTMLDivElement | null>(null);
+    const openWidget = useOpenWidget();
 
     const assetList = useFetchAssetList({ skip: !active });
 
@@ -123,7 +125,7 @@ export const FormsTopDown = forwardRef(function FormsTopDown(_props, ref) {
                 });
             },
         }),
-        [renderedForms, view?.measure]
+        [renderedForms, view?.measure],
     );
 
     if (!view?.measure || locationForms.length === 0) {
@@ -141,7 +143,7 @@ export const FormsTopDown = forwardRef(function FormsTopDown(_props, ref) {
         } else {
             dispatch(formsActions.setCurrentFormsList(templateId));
             dispatch(formsActions.setSelectedFormId(id));
-            dispatch(explorerActions.forceOpenWidget(featuresConfig.forms.key));
+            openWidget(featuresConfig.forms.key, { force: true });
         }
     };
 
@@ -197,7 +199,7 @@ const FormButton = styled(IconButton, { shouldForwardProp: (prop) => prop !== "a
         &:hover {
             background-color: ${active ? theme.palette.primary.dark : theme.palette.secondary.dark};
         }
-    `
+    `,
 );
 
 const StateDot = styled("div")<{ state: FormState }>(
@@ -210,5 +212,5 @@ const StateDot = styled("div")<{ state: FormState }>(
         border-radius: 12px;
         border: 2px solid white;
         background: ${stateColors.get(state)};
-    `
+    `,
 );

--- a/src/features/forms/hooks/useLocationFormAssetClickHandler.ts
+++ b/src/features/forms/hooks/useLocationFormAssetClickHandler.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 
 import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { featuresConfig } from "config/features";
-import { explorerActions } from "slices/explorer";
+import { useOpenWidget } from "hooks/useOpenWidget";
 
 import { useLazyFormsGlobals } from "../formsGlobals/hooks";
 import { formsActions, selectCurrentFormsList, selectSelectedFormId } from "../slice";
@@ -12,6 +12,7 @@ export function useLocationFormAssetClickHandler() {
     const lazyFormsGlobals = useLazyFormsGlobals();
     const selectedTemplateId = useAppSelector(selectCurrentFormsList);
     const selectedFormId = useAppSelector(selectSelectedFormId);
+    const openWidget = useOpenWidget();
     const dispatch = useAppDispatch();
 
     return useCallback(
@@ -28,13 +29,13 @@ export function useLocationFormAssetClickHandler() {
             if (!isSelected) {
                 dispatch(formsActions.setCurrentFormsList(templateId));
                 dispatch(formsActions.setSelectedFormId(formId));
-                dispatch(explorerActions.forceOpenWidget(featuresConfig.forms.key));
+                openWidget(featuresConfig.forms.key, { force: true });
             } else {
                 dispatch(formsActions.setSelectedFormId(undefined));
             }
 
             return true;
         },
-        [dispatch, lazyFormsGlobals, selectedTemplateId, selectedFormId]
+        [dispatch, lazyFormsGlobals, selectedTemplateId, selectedFormId, openWidget],
     );
 }

--- a/src/features/groupedWidgetList/groupedWidgetList.tsx
+++ b/src/features/groupedWidgetList/groupedWidgetList.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 
-import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { useAppSelector } from "app/redux-store-interactions";
 import { FeatureGroupKey, featuresConfig, type WidgetKey } from "config/features";
-import { explorerActions, selectWidgets } from "slices/explorer";
+import { useOpenWidget } from "hooks/useOpenWidget";
+import { selectWidgets } from "slices/explorer";
 
 import { Root } from "./routes/root";
 
@@ -16,11 +17,11 @@ export default function GroupedWidgetList({
     onSelect: () => void;
 }) {
     const activeWidgets = useAppSelector(selectWidgets);
-    const dispatch = useAppDispatch();
     const config = widgetKey ? featuresConfig[widgetKey] : undefined;
     const [expandedGroupKey, setExpandedGroupKey] = useState(
-        featureGroupKey || (config && "groups" in config && config.groups[0]) || null
+        featureGroupKey || (config && "groups" in config && config.groups[0]) || null,
     );
+    const openWidget = useOpenWidget();
 
     useEffect(() => {
         if (featureGroupKey) {
@@ -37,11 +38,12 @@ export default function GroupedWidgetList({
 
         if (!widgetKey) {
             onSelect();
-            return dispatch(explorerActions.addWidgetSlot(key));
+            openWidget(key);
+            return;
         }
 
         onSelect();
-        dispatch(explorerActions.replaceWidgetSlot({ replace: widgetKey, key }));
+        openWidget(key, { replace: widgetKey });
     };
 
     return (

--- a/src/features/measure/measureInteractions.tsx
+++ b/src/features/measure/measureInteractions.tsx
@@ -8,7 +8,8 @@ import { useExplorerGlobals } from "contexts/explorerGlobals";
 import { areaActions, selectAreas } from "features/area";
 import { pointLineActions, selectPointLines } from "features/pointLine";
 import { Picker, renderActions } from "features/render";
-import { explorerActions, selectEnabledWidgets } from "slices/explorer";
+import { useOpenWidget } from "hooks/useOpenWidget";
+import { selectEnabledWidgets } from "slices/explorer";
 
 import { measureActions, selectMeasure } from "./measureSlice";
 
@@ -26,7 +27,7 @@ const RemoveMarker = styled(
             <path d="M96,96 L104,104 M104,96 L96,104" stroke="white" strokeWidth={2}></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(basicStyle);
 
 const InfoMarker = styled(
@@ -41,7 +42,7 @@ const InfoMarker = styled(
             ></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(basicStyle);
 
 const UndoMarker = styled(
@@ -57,7 +58,7 @@ const UndoMarker = styled(
             ></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(basicStyle);
 
 const FinalizeMarker = styled(
@@ -72,7 +73,7 @@ const FinalizeMarker = styled(
             ></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(basicStyle);
 
 const ConnectMarker = styled(
@@ -88,7 +89,7 @@ const ConnectMarker = styled(
             ></path>
         </g>
     ),
-    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" }
+    { shouldForwardProp: (prop) => prop !== "active" && prop !== "hovered" },
 )(basicStyle);
 
 export type MeasureInteractionPositions = {
@@ -115,6 +116,7 @@ export function MeasureInteractions() {
     const pointLines = useAppSelector(selectPointLines);
     const widgetIsEnabled =
         useAppSelector(selectEnabledWidgets).find((widget) => widget.key === featuresConfig.measure.key) !== undefined;
+    const openWidget = useOpenWidget();
 
     return (
         <>
@@ -136,14 +138,14 @@ export function MeasureInteractions() {
                                         name={`infoMeasure-${idx}`}
                                         onClick={() => {
                                             dispatch(measureActions.selectMeasureSet(idx));
-                                            dispatch(explorerActions.forceOpenWidget(featuresConfig.measure.key));
+                                            openWidget(featuresConfig.measure.key, { force: true });
                                         }}
                                     />
                                 )}
                             </>
                         }
                     </Fragment>
-                ) : null
+                ) : null,
             )}
             {measure.duoMeasurementValues.map((result, idx) =>
                 result ? (
@@ -191,7 +193,7 @@ export function MeasureInteractions() {
                             }}
                         />
                     </Fragment>
-                ) : null
+                ) : null,
             )}
             {areas.map((area, idx) =>
                 area.points.length && area.area !== -1 ? (
@@ -224,11 +226,11 @@ export function MeasureInteractions() {
                             name={`infoArea-${idx}`}
                             onClick={() => {
                                 dispatch(areaActions.setCurrentArea(idx));
-                                dispatch(explorerActions.forceOpenWidget(featuresConfig.area.key));
+                                openWidget(featuresConfig.area.key, { force: true });
                             }}
                         />
                     </Fragment>
-                ) : null
+                ) : null,
             )}
 
             {pointLines.map((pointLine, idx) => (
@@ -272,7 +274,7 @@ export function MeasureInteractions() {
                                 name={`infoPl-${idx}`}
                                 onClick={() => {
                                     dispatch(pointLineActions.setCurrent(idx));
-                                    dispatch(explorerActions.forceOpenWidget(featuresConfig.pointLine.key));
+                                    openWidget(featuresConfig.pointLine.key, { force: true });
                                 }}
                             />
                         </>

--- a/src/features/pointVisualization/pointVisualization.tsx
+++ b/src/features/pointVisualization/pointVisualization.tsx
@@ -12,8 +12,9 @@ import { selectSelectedProfile } from "features/deviations";
 import { selectDefaultPointVisualization, selectPoints, selectTerrain, selectViewMode } from "features/render";
 import WidgetList from "features/widgetList/widgetList";
 import { useCheckProjectPermission } from "hooks/useCheckProjectPermissions";
+import { useOpenWidget } from "hooks/useOpenWidget";
 import { useToggle } from "hooks/useToggle";
-import { explorerActions, selectMaximized, selectMinimized } from "slices/explorer";
+import { selectMaximized, selectMinimized } from "slices/explorer";
 import { ViewMode } from "types/misc";
 
 import { Header } from "./components/header";
@@ -49,6 +50,7 @@ function PointVisualizationInner() {
     const isDeviationMode = useAppSelector(selectViewMode) === ViewMode.Deviations && deviationProfile;
     const history = useHistory();
     const location = useLocation();
+    const openWidget = useOpenWidget();
 
     useEffect(() => {
         return () => {
@@ -64,7 +66,7 @@ function PointVisualizationInner() {
     }, [history, defaultPointVisualization]);
 
     const openDeviations = () => {
-        dispatch(explorerActions.forceOpenWidget(featuresConfig.deviations.key));
+        openWidget(featuresConfig.deviations.key, { force: true });
     };
 
     return (

--- a/src/features/propertyTree/propertyTree.tsx
+++ b/src/features/propertyTree/propertyTree.tsx
@@ -18,9 +18,10 @@ import {
 import { featuresConfig } from "config/features";
 import WidgetList from "features/widgetList/widgetList";
 import { useAbortController } from "hooks/useAbortController";
+import { useOpenWidget } from "hooks/useOpenWidget";
 import { useSceneId } from "hooks/useSceneId";
 import { useToggle } from "hooks/useToggle";
-import { explorerActions, selectMaximized, selectMinimized, selectProjectIsV2 } from "slices/explorer";
+import { selectMaximized, selectMinimized, selectProjectIsV2 } from "slices/explorer";
 import { AsyncStatus } from "types/misc";
 import { secondsToMs } from "utils/time";
 
@@ -40,6 +41,7 @@ export default function PropertyTree() {
     const isLoading = useAppSelector(selectIsPropertyTreeLoading);
     const activeGroups = useAppSelector(selectPropertyTreeBookmarkState);
     const groupsCreationStatus = useAppSelector((state) => state.propertyTree.groupsCreationStatus);
+    const openWidget = useOpenWidget();
 
     const { data: favorites = [], isLoading: isLoadingFavorites } = useGetPropertyTreeFavoritesQuery(
         { projectId: sceneId },
@@ -187,7 +189,7 @@ export default function PropertyTree() {
                                     aria-label="close"
                                     color="inherit"
                                     onClick={() => {
-                                        dispatch(explorerActions.forceOpenWidget(featuresConfig.groups.key));
+                                        openWidget(featuresConfig.groups.key, { force: true });
                                         dispatch(propertyTreeActions.setGroupsCreationStatus(AsyncStatus.Initial));
                                     }}
                                 >

--- a/src/features/widgetList/widgetList.tsx
+++ b/src/features/widgetList/widgetList.tsx
@@ -1,10 +1,10 @@
 import { MemoryRouter, Route, Switch } from "react-router-dom";
 
-import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { useAppSelector } from "app/redux-store-interactions";
 import { FeatureGroupKey, featuresConfig, type WidgetKey } from "config/features";
 import GroupedWidgetList from "features/groupedWidgetList/groupedWidgetList";
-import { explorerActions, selectNewDesign, selectWidgets } from "slices/explorer";
-import { mixpanel } from "utils/mixpanel";
+import { useOpenWidget } from "hooks/useOpenWidget";
+import { selectNewDesign, selectWidgets } from "slices/explorer";
 
 import { Root } from "./routes/root";
 import { Tag } from "./routes/tag";
@@ -24,7 +24,7 @@ export default function WidgetList(props: {
 
 function WidgetListInner({ widgetKey, onSelect }: { widgetKey?: WidgetKey; onSelect: () => void }) {
     const activeWidgets = useAppSelector(selectWidgets);
-    const dispatch = useAppDispatch();
+    const openWidget = useOpenWidget();
 
     const handleClick = (key: WidgetKey) => () => {
         const active = key !== widgetKey && activeWidgets.includes(key);
@@ -35,13 +35,12 @@ function WidgetListInner({ widgetKey, onSelect }: { widgetKey?: WidgetKey; onSel
 
         if (!widgetKey) {
             onSelect();
-            mixpanel?.track("Opened Widget", { "Widget Key": key });
-            return dispatch(explorerActions.addWidgetSlot(key));
+            openWidget(key);
+            return;
         }
 
         onSelect();
-        mixpanel?.track("Opened Widget", { "Widget Key": key });
-        dispatch(explorerActions.replaceWidgetSlot({ replace: widgetKey, key }));
+        openWidget(key, { replace: widgetKey });
     };
 
     const config = widgetKey ? featuresConfig[widgetKey] : undefined;

--- a/src/features/widgets/widgets.tsx
+++ b/src/features/widgets/widgets.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
 import { WidgetErrorBoundary, WidgetSkeleton } from "components";
 import { featuresConfig, WidgetKey } from "config/features";
 import { MenuWidget } from "features/menuWidget";
+import { useRemoveWidget } from "hooks/useRemoveWidget";
 import {
     explorerActions,
     selectGridSize,
@@ -21,7 +22,6 @@ import {
 import { PositionedWidgetState } from "slices/explorer/types";
 import { getNextSlotPos, getTakenWidgetSlotCount } from "slices/explorer/utils";
 import { compareStrings } from "utils/misc";
-import { mixpanel } from "utils/mixpanel";
 
 const Properties = lazy(() => import("features/properties/properties"));
 const PropertiesTree = lazy(() => import("features/propertyTree/propertyTree"));
@@ -84,6 +84,7 @@ function NewWidgets() {
     const slots = useAppSelector(selectWidgets);
     const positionedWidgets = useAppSelector(selectPositionedWidgets);
     const dispatch = useAppDispatch();
+    const removeWidget = useRemoveWidget();
 
     const showNewSlot = useMemo(() => {
         return widgetSlot.open && getTakenWidgetSlotCount(slots, maximized, maximizedHorizontal) < layout.widgets;
@@ -103,11 +104,11 @@ function NewWidgets() {
         if (!isOnline) {
             slots.forEach((slot) => {
                 if (!featuresConfig[slot].offline) {
-                    dispatch(explorerActions.removeWidgetSlot(slot));
+                    removeWidget(slot, { reason: "offline" });
                 }
             });
         }
-    }, [dispatch, isOnline, slots]);
+    }, [isOnline, slots, removeWidget]);
 
     const positionedSlots = useMemo(() => {
         const gap = theme.spacing(2);
@@ -230,6 +231,7 @@ function OldWidgets() {
     const layout = useAppSelector(selectWidgetLayout);
     const slots = useAppSelector(selectWidgets);
     const dispatch = useAppDispatch();
+    const removeWidget = useRemoveWidget();
 
     useEffect(
         function handleSettingsChange() {
@@ -245,12 +247,11 @@ function OldWidgets() {
         if (!isOnline) {
             slots.forEach((slot) => {
                 if (!featuresConfig[slot].offline) {
-                    mixpanel?.track("Closed Widget", { "Widget Key": slot });
-                    dispatch(explorerActions.removeWidgetSlot(slot));
+                    removeWidget(slot, { reason: "offline" });
                 }
             });
         }
-    }, [dispatch, isOnline, slots]);
+    }, [isOnline, slots, removeWidget]);
 
     const getGridLayout = () => {
         if (layout.widgets === 4) {

--- a/src/hooks/useOpenWidget.ts
+++ b/src/hooks/useOpenWidget.ts
@@ -26,6 +26,10 @@ export function useOpenWidget() {
 
     return useCallback(
         (widgetKey: WidgetKey, params: { replace?: WidgetKey } | { force?: boolean } = {}) => {
+            if (widgets.includes(widgetKey)) {
+                return;
+            }
+
             const replace = "replace" in params ? params.replace : false;
             const force = "force" in params ? params.force : false;
 
@@ -36,9 +40,7 @@ export function useOpenWidget() {
                 mixpanel?.track("Closed Widget", { "Widget Key": key });
             };
 
-            if (widgets.includes(widgetKey)) {
-                // already open, noop
-            } else if (replace && widgets.includes(replace)) {
+            if (replace && widgets.includes(replace)) {
                 trackClosed(replace);
                 trackOpened(widgetKey);
                 dispatch(explorerActions.replaceWidgetSlot({ replace: replace, key: widgetKey }));

--- a/src/hooks/useRemoveWidget.ts
+++ b/src/hooks/useRemoveWidget.ts
@@ -12,11 +12,11 @@ export function useRemoveWidget() {
     return useCallback(
         (widgetKey: WidgetKey, { reason }: { reason?: "offline" } = {}) => {
             if (!widgets.includes(widgetKey)) {
-                // not open, noop
-            } else {
-                mixpanel?.track("Closed Widget", { "Widget Key": widgetKey, "Close Reason": reason });
-                dispatch(explorerActions.removeWidgetSlot(widgetKey));
+                return;
             }
+
+            mixpanel?.track("Closed Widget", { "Widget Key": widgetKey, "Close Reason": reason });
+            dispatch(explorerActions.removeWidgetSlot(widgetKey));
         },
         [widgets, dispatch],
     );

--- a/src/hooks/useRemoveWidget.ts
+++ b/src/hooks/useRemoveWidget.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+
+import { useAppDispatch, useAppSelector } from "app/redux-store-interactions";
+import { WidgetKey } from "config/features";
+import { explorerActions, selectWidgets } from "slices/explorer";
+import { mixpanel } from "utils/mixpanel";
+
+export function useRemoveWidget() {
+    const widgets = useAppSelector(selectWidgets);
+    const dispatch = useAppDispatch();
+
+    return useCallback(
+        (widgetKey: WidgetKey, { reason }: { reason?: "offline" } = {}) => {
+            if (!widgets.includes(widgetKey)) {
+                // not open, noop
+            } else {
+                mixpanel?.track("Closed Widget", { "Widget Key": widgetKey, "Close Reason": reason });
+                dispatch(explorerActions.removeWidgetSlot(widgetKey));
+            }
+        },
+        [widgets, dispatch],
+    );
+}


### PR DESCRIPTION
https://trello.com/c/9Qd0122a/900-mixpanel-widget-events-are-not-sent-in-new-ux-and-in-some-other-cases

Add/patched hooks `useOpenWidget` and `useRemoveWidget`
- `useOpenWidget` should be used instead of `addWidgetSlot`, `forceOpenWidget`, `replaceWidgetSlot`
- `useRemoveWidget` should be used instead of `removeWidgetSlot`

Using hooks ensures proper mixpanel reporting of "Opened Widget" and "Closed Widget" event